### PR TITLE
context: Add print to context globals.

### DIFF
--- a/context_test.go
+++ b/context_test.go
@@ -8,6 +8,20 @@ import (
 	"rogchap.com/v8go"
 )
 
+func TestLog(t *testing.T) {
+	t.Parallel()
+	ctx, err := v8go.NewContext(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx.RunScript(`const printtest = () => { print(42); return 42; }`, "add.js")
+	val, _ := ctx.RunScript(`printtest(42)`, "main.js")
+	rtn := val.String()
+	if rtn != "42" {
+		t.Errorf("script returned an unexpected value: expected %q, got %q", "42", rtn)
+	}
+}
+
 func TestContextExec(t *testing.T) {
 	t.Parallel()
 	ctx, _ := v8go.NewContext(nil)

--- a/value.go
+++ b/value.go
@@ -17,6 +17,12 @@ type Value struct {
 // are returned as-is, objects will return `[object Object]` and functions will
 // print their definition.
 func (v *Value) String() string {
+	if v == nil {
+		return "<nil value>"
+	}
+	if v.ptr == nil {
+		return "<nil ptr>"
+	}
 	s := C.ValueToString(v.ptr)
 	defer C.free(unsafe.Pointer(s))
 	return C.GoString(s)


### PR DESCRIPTION
This is a the first step in supplying some bi-directional interoperability between the v8 isolates and Go.