### PR TITLE
Add (Basic) getter methods for the v8 value struct

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Value methods for checking value kind (is string, number, array etc)
 - C formatting via `clang-format` to aid future development
 - Support of vendoring with `go mod vendor`
+- Value methods to convert to primitive data types
 
 ### Changed
 - Use g++ (default for cgo) for linux builds of the static v8 lib

--- a/errors_test.go
+++ b/errors_test.go
@@ -7,7 +7,7 @@ import (
 	"rogchap.com/v8go"
 )
 
-func TestFormatting(t *testing.T) {
+func TestErrorFormatting(t *testing.T) {
 	t.Parallel()
 	tests := [...]struct {
 		name            string

--- a/v8go.cc
+++ b/v8go.cc
@@ -216,6 +216,18 @@ void ValueDispose(ValuePtr ptr) {
   delete static_cast<m_value*>(ptr);
 }
 
+const uint32_t* ValueToArrayIndex(ValuePtr ptr) {
+  LOCAL_VALUE(ptr);
+  MaybeLocal<Uint32> array_index = value->ToArrayIndex(ctx->ptr.Get(iso));
+  if (array_index.IsEmpty()) {
+    return nullptr;
+  }
+
+  uint32_t* idx = new uint32_t;
+  *idx = array_index.ToLocalChecked()->Value();
+  return idx;
+}
+
 const char* ValueToString(ValuePtr ptr) {
   LOCAL_VALUE(ptr);
   String::Utf8Value utf8(iso, value);
@@ -223,8 +235,8 @@ const char* ValueToString(ValuePtr ptr) {
 }
 
 int ValueToBoolean(ValuePtr ptr) {
-    LOCAL_VALUE(ptr);
-    return value->BooleanValue(iso);
+  LOCAL_VALUE(ptr);
+  return value->BooleanValue(iso);
 }
 
 int ValueIsUndefined(ValuePtr ptr) {

--- a/v8go.cc
+++ b/v8go.cc
@@ -261,6 +261,11 @@ const char* ValueToString(ValuePtr ptr) {
   return CopyString(utf8);
 }
 
+uint32_t ValueToUint32(ValuePtr ptr) {
+  LOCAL_VALUE(ptr);
+  return value->Uint32Value(ctx->ptr.Get(iso)).ToChecked();
+}
+
 int ValueIsUndefined(ValuePtr ptr) {
   LOCAL_VALUE(ptr);
   return value->IsUndefined();

--- a/v8go.cc
+++ b/v8go.cc
@@ -228,15 +228,20 @@ const uint32_t* ValueToArrayIndex(ValuePtr ptr) {
   return idx;
 }
 
+int ValueToBoolean(ValuePtr ptr) {
+  LOCAL_VALUE(ptr);
+  return value->BooleanValue(iso);
+}
+
+int32_t ValueToInt32(ValuePtr ptr) {
+  LOCAL_VALUE(ptr);
+  return value->Int32Value(ctx->ptr.Get(iso)).ToChecked();
+}
+
 const char* ValueToString(ValuePtr ptr) {
   LOCAL_VALUE(ptr);
   String::Utf8Value utf8(iso, value);
   return CopyString(utf8);
-}
-
-int ValueToBoolean(ValuePtr ptr) {
-  LOCAL_VALUE(ptr);
-  return value->BooleanValue(iso);
 }
 
 int ValueIsUndefined(ValuePtr ptr) {

--- a/v8go.cc
+++ b/v8go.cc
@@ -238,6 +238,11 @@ int32_t ValueToInt32(ValuePtr ptr) {
   return value->Int32Value(ctx->ptr.Get(iso)).ToChecked();
 }
 
+int64_t ValueToInteger(ValuePtr ptr) {
+  LOCAL_VALUE(ptr);
+  return value->IntegerValue(ctx->ptr.Get(iso)).ToChecked();
+}
+
 const char* ValueToString(ValuePtr ptr) {
   LOCAL_VALUE(ptr);
   String::Utf8Value utf8(iso, value);

--- a/v8go.cc
+++ b/v8go.cc
@@ -248,6 +248,13 @@ double ValueToNumber(ValuePtr ptr) {
   return value->NumberValue(ctx->ptr.Get(iso)).ToChecked();
 }
 
+const char* ValueToDetailString(ValuePtr ptr) {
+  LOCAL_VALUE(ptr);
+  String::Utf8Value ds(
+      iso, value->ToDetailString(ctx->ptr.Get(iso)).ToLocalChecked());
+  return CopyString(ds);
+}
+
 const char* ValueToString(ValuePtr ptr) {
   LOCAL_VALUE(ptr);
   String::Utf8Value utf8(iso, value);

--- a/v8go.cc
+++ b/v8go.cc
@@ -222,6 +222,11 @@ const char* ValueToString(ValuePtr ptr) {
   return CopyString(utf8);
 }
 
+int ValueToBoolean(ValuePtr ptr) {
+    LOCAL_VALUE(ptr);
+    return value->BooleanValue(iso);
+}
+
 int ValueIsUndefined(ValuePtr ptr) {
   LOCAL_VALUE(ptr);
   return value->IsUndefined();

--- a/v8go.cc
+++ b/v8go.cc
@@ -243,6 +243,11 @@ int64_t ValueToInteger(ValuePtr ptr) {
   return value->IntegerValue(ctx->ptr.Get(iso)).ToChecked();
 }
 
+double ValueToNumber(ValuePtr ptr) {
+  LOCAL_VALUE(ptr);
+  return value->NumberValue(ctx->ptr.Get(iso)).ToChecked();
+}
+
 const char* ValueToString(ValuePtr ptr) {
   LOCAL_VALUE(ptr);
   String::Utf8Value utf8(iso, value);

--- a/v8go.h
+++ b/v8go.h
@@ -53,6 +53,7 @@ const char* ValueToString(ValuePtr ptr);
 const uint32_t* ValueToArrayIndex(ValuePtr ptr);
 int ValueToBoolean(ValuePtr ptr);
 int32_t ValueToInt32(ValuePtr ptr);
+int64_t ValueToInteger(ValuePtr ptr);
 int ValueIsUndefined(ValuePtr ptr);
 int ValueIsNull(ValuePtr ptr);
 int ValueIsNullOrUndefined(ValuePtr ptr);

--- a/v8go.h
+++ b/v8go.h
@@ -55,7 +55,7 @@ int ValueToBoolean(ValuePtr ptr);
 int32_t ValueToInt32(ValuePtr ptr);
 int64_t ValueToInteger(ValuePtr ptr);
 double ValueToNumber(ValuePtr ptr);
-// const char* ValueToDetailString(ValuePtr ptr);
+const char* ValueToDetailString(ValuePtr ptr);
 int ValueIsUndefined(ValuePtr ptr);
 int ValueIsNull(ValuePtr ptr);
 int ValueIsNullOrUndefined(ValuePtr ptr);

--- a/v8go.h
+++ b/v8go.h
@@ -49,6 +49,7 @@ extern RtnValue RunScript(ContextPtr ctx_ptr,
 
 extern void ValueDispose(ValuePtr ptr);
 const char* ValueToString(ValuePtr ptr);
+int ValueToBoolean(ValuePtr ptr);
 int ValueIsUndefined(ValuePtr ptr);
 int ValueIsNull(ValuePtr ptr);
 int ValueIsNullOrUndefined(ValuePtr ptr);

--- a/v8go.h
+++ b/v8go.h
@@ -54,6 +54,8 @@ const uint32_t* ValueToArrayIndex(ValuePtr ptr);
 int ValueToBoolean(ValuePtr ptr);
 int32_t ValueToInt32(ValuePtr ptr);
 int64_t ValueToInteger(ValuePtr ptr);
+double ValueToNumber(ValuePtr ptr);
+// const char* ValueToDetailString(ValuePtr ptr);
 int ValueIsUndefined(ValuePtr ptr);
 int ValueIsNull(ValuePtr ptr);
 int ValueIsNullOrUndefined(ValuePtr ptr);

--- a/v8go.h
+++ b/v8go.h
@@ -52,6 +52,7 @@ extern void ValueDispose(ValuePtr ptr);
 const char* ValueToString(ValuePtr ptr);
 const uint32_t* ValueToArrayIndex(ValuePtr ptr);
 int ValueToBoolean(ValuePtr ptr);
+int32_t ValueToInt32(ValuePtr ptr);
 int ValueIsUndefined(ValuePtr ptr);
 int ValueIsNull(ValuePtr ptr);
 int ValueIsNullOrUndefined(ValuePtr ptr);

--- a/v8go.h
+++ b/v8go.h
@@ -56,6 +56,7 @@ int32_t ValueToInt32(ValuePtr ptr);
 int64_t ValueToInteger(ValuePtr ptr);
 double ValueToNumber(ValuePtr ptr);
 const char* ValueToDetailString(ValuePtr ptr);
+uint32_t ValueToUint32(ValuePtr ptr);
 int ValueIsUndefined(ValuePtr ptr);
 int ValueIsNull(ValuePtr ptr);
 int ValueIsNullOrUndefined(ValuePtr ptr);

--- a/v8go.h
+++ b/v8go.h
@@ -5,6 +5,7 @@ extern "C" {
 #endif
 
 #include <stddef.h>
+#include <stdint.h>
 
 typedef void* IsolatePtr;
 typedef void* ContextPtr;
@@ -49,6 +50,7 @@ extern RtnValue RunScript(ContextPtr ctx_ptr,
 
 extern void ValueDispose(ValuePtr ptr);
 const char* ValueToString(ValuePtr ptr);
+const uint32_t* ValueToArrayIndex(ValuePtr ptr);
 int ValueToBoolean(ValuePtr ptr);
 int ValueIsUndefined(ValuePtr ptr);
 int ValueIsNull(ValuePtr ptr);

--- a/value.go
+++ b/value.go
@@ -43,7 +43,8 @@ func (v *Value) ArrayIndex() (idx uint32, ok bool) {
 }
 
 // BigInt perform the equivalent of `BigInt(value)` in JS.
-func (v *Value) BigInt() struct{} { // *BigInt
+func (v *Value) bigInt() struct{} { // *BigInt
+	//TODO(rogchap): implement and export public API
 	panic("not implemented")
 }
 
@@ -77,7 +78,9 @@ func (v *Value) Number() float64 {
 	return float64(C.ValueToNumber(v.ptr))
 }
 
-func (v *Value) Object() struct{} { // *Object
+// Object perform the equivalent of Object(value) in JS.
+func (v *Value) object() struct{} { // *Object
+	//TODO(rogchap): implement and export public API
 	panic("not implemented")
 }
 
@@ -92,8 +95,8 @@ func (v *Value) String() string {
 
 // Uint32 perform the equivalent of `Number(value)` in JS and convert the result to an
 // unsigned 32-bit integer by performing the steps in https://tc39.es/ecma262/#sec-touint32.
-func Uint32() uint32 {
-	panic("not implemented")
+func (v *Value) Uint32() uint32 {
+	return uint32(C.ValueToUint32(v.ptr))
 }
 
 // IsUndefined returns true if this value is the undefined value. See ECMA-262 4.3.10.

--- a/value.go
+++ b/value.go
@@ -13,7 +13,50 @@ type Value struct {
 	ptr C.ValuePtr
 }
 
-// String will return the string representation of the value. Primitive values
+// ArrayIndex converts a string to an array index
+func (v *Value) ArrayIndex() uint32 {
+	//TODO(rogchap): What should we do if this fails? Return an error?
+	panic("not implemented")
+}
+
+// BigInt perform the equivalent of `BigInt(value)` in JS.
+func (v *Value) BigInt() struct{} { // *BigInt
+	panic("not implemented")
+}
+
+// Boolean perform the equivalent of `Boolean(value)` in JS. This can never fail.
+func (v *Value) Boolean() bool {
+	return C.ValueToBoolean(v.ptr) != 0
+}
+
+// DetailString provide a string representation of this value usable for debugging.
+func (v *Value) DetailString() string {
+	panic("not implemented")
+}
+
+// Int32 perform the equivalent of `Number(value)` in JS and convert the result to a
+// signed 32-bit integer by performing the steps in https://tc39.es/ecma262/#sec-toint32.
+func (v *Value) Int32() int32 {
+	panic("not implemented")
+}
+
+// Integer perform the equivalent of `Number(value)` in JS and convert the result to an integer.
+// Negative values are rounded up, positive values are rounded down. NaN is converted to 0.
+// Infinite values yield undefined results.
+func (v *Value) Integer() int64 {
+	panic("not implemented")
+}
+
+// Number perform the equivalent of `Number(value)` in JS.
+func (v *Value) Number() float64 {
+	panic("not implemented")
+}
+
+func (v *Value) Object() struct{} { // *Object
+	panic("not implemented")
+}
+
+// String perform the equivalent of `String(value)` in JS. Primitive values
 // are returned as-is, objects will return `[object Object]` and functions will
 // print their definition.
 func (v *Value) String() string {
@@ -22,9 +65,10 @@ func (v *Value) String() string {
 	return C.GoString(s)
 }
 
-// Boolean perform the equivalent of Boolean(value) in JS. This can never fail.
-func (v *Value) Boolean() bool {
-	return C.ValueToBoolean(v.ptr) != 0
+// Uint32 perform the equivalent of `Number(value)` in JS and convert the result to an
+// unsigned 32-bit integer by performing the steps in https://tc39.es/ecma262/#sec-touint32.
+func Uint32() uint32 {
+	panic("not implemented")
 }
 
 // IsUndefined returns true if this value is the undefined value. See ECMA-262 4.3.10.

--- a/value.go
+++ b/value.go
@@ -41,7 +41,7 @@ func (v *Value) DetailString() string {
 // Int32 perform the equivalent of `Number(value)` in JS and convert the result to a
 // signed 32-bit integer by performing the steps in https://tc39.es/ecma262/#sec-toint32.
 func (v *Value) Int32() int32 {
-	panic("not implemented")
+	return int32(C.ValueToInt32(v.ptr))
 }
 
 // Integer perform the equivalent of `Number(value)` in JS and convert the result to an integer.

--- a/value.go
+++ b/value.go
@@ -48,7 +48,7 @@ func (v *Value) Int32() int32 {
 // Negative values are rounded up, positive values are rounded down. NaN is converted to 0.
 // Infinite values yield undefined results.
 func (v *Value) Integer() int64 {
-	panic("not implemented")
+	return int64(C.ValueToInteger(v.ptr))
 }
 
 // Number perform the equivalent of `Number(value)` in JS.

--- a/value.go
+++ b/value.go
@@ -53,7 +53,7 @@ func (v *Value) Integer() int64 {
 
 // Number perform the equivalent of `Number(value)` in JS.
 func (v *Value) Number() float64 {
-	panic("not implemented")
+	return float64(C.ValueToNumber(v.ptr))
 }
 
 func (v *Value) Object() struct{} { // *Object

--- a/value.go
+++ b/value.go
@@ -13,10 +13,14 @@ type Value struct {
 	ptr C.ValuePtr
 }
 
-// ArrayIndex converts a string to an array index
-func (v *Value) ArrayIndex() uint32 {
-	//TODO(rogchap): What should we do if this fails? Return an error?
-	panic("not implemented")
+// ArrayIndex attempts to converts a string to an array index. Returns ok false if conversion fails.
+func (v *Value) ArrayIndex() (idx uint32, ok bool) {
+	arrayIdx := C.ValueToArrayIndex(v.ptr)
+	defer C.free(unsafe.Pointer(arrayIdx))
+	if arrayIdx == nil {
+		return 0, false
+	}
+	return uint32(*arrayIdx), true
 }
 
 // BigInt perform the equivalent of `BigInt(value)` in JS.

--- a/value.go
+++ b/value.go
@@ -22,6 +22,11 @@ func (v *Value) String() string {
 	return C.GoString(s)
 }
 
+// Boolean perform the equivalent of Boolean(value) in JS. This can never fail.
+func (v *Value) Boolean() bool {
+	return C.ValueToBoolean(v.ptr) != 0
+}
+
 // IsUndefined returns true if this value is the undefined value. See ECMA-262 4.3.10.
 func (v *Value) IsUndefined() bool {
 	return C.ValueIsUndefined(v.ptr) != 0

--- a/value_test.go
+++ b/value_test.go
@@ -282,6 +282,30 @@ func TestValueNumber(t *testing.T) {
 	}
 }
 
+func TestValueUint32(t *testing.T) {
+	t.Parallel()
+	ctx, _ := v8go.NewContext(nil)
+	tests := [...]struct {
+		source   string
+		expected uint32
+	}{
+		{"0", 0},
+		{"1", 1},
+		{"-1", 1<<32 - 1}, // overflow
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.source, func(t *testing.T) {
+			t.Parallel()
+			val, _ := ctx.RunScript(tt.source, "test.js")
+			if u32 := val.Uint32(); u32 != tt.expected {
+				t.Errorf("unexpected value: expected %v, got %v", tt.expected, u32)
+			}
+		})
+	}
+}
+
 func TestValueIsXXX(t *testing.T) {
 	t.Parallel()
 	iso, _ := v8go.NewIsolate()

--- a/value_test.go
+++ b/value_test.go
@@ -138,6 +138,41 @@ func TestValueInt32(t *testing.T) {
 	}
 }
 
+func TestValueInteger(t *testing.T) {
+	t.Parallel()
+	ctx, _ := v8go.NewContext(nil)
+	tests := [...]struct {
+		source   string
+		expected int64
+	}{
+		{"0", 0},
+		{"1", 1},
+		{"-1", -1},
+		{"'1'", 1},
+		{"'a'", 0},
+		{"[1]", 1},
+		{"[1,1]", 0},
+		{"Infinity", 1<<63 - 1},
+		{"Number.MAX_SAFE_INTEGER", 1<<53 - 1},
+		{"Number.MIN_SAFE_INTEGER", -(1<<53 - 1)},
+		{"Number.NaN", 0},
+		{"9_007_199_254_740_991", 1<<53 - 1},
+		{"-9_007_199_254_740_991", -(1<<53 - 1)},
+		{"9_223_372_036_854_775_810", 1<<63 - 1}, // does not overflow, pinned at 2^64 -1
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.source, func(t *testing.T) {
+			t.Parallel()
+			val, _ := ctx.RunScript(tt.source, "test.js")
+			if i64 := val.Integer(); i64 != tt.expected {
+				t.Errorf("unexpected value: expected %v, got %v", tt.expected, i64)
+			}
+		})
+	}
+}
+
 func TestValueIsXXX(t *testing.T) {
 	t.Parallel()
 	iso, _ := v8go.NewIsolate()

--- a/value_test.go
+++ b/value_test.go
@@ -29,7 +29,7 @@ func TestValueString(t *testing.T) {
 			result, _ := ctx.RunScript(tt.source, "test.js")
 			str := result.String()
 			if str != tt.out {
-				t.Errorf("unespected result: expected %q, got %q", tt.out, str)
+				t.Errorf("unexpected result: expected %q, got %q", tt.out, str)
 			}
 		})
 	}
@@ -61,10 +61,47 @@ func TestValueBoolean(t *testing.T) {
 			t.Parallel()
 			val, _ := ctx.RunScript(tt.source, "test.js")
 			if b := val.Boolean(); b != tt.out {
-				t.Errorf("unespected value: expected %v, got %v", tt.out, b)
+				t.Errorf("unexpected value: expected %v, got %v", tt.out, b)
 			}
 		})
 	}
+}
+
+func TestValueArrayIndex(t *testing.T) {
+	t.Parallel()
+	ctx, _ := v8go.NewContext(nil)
+	tests := [...]struct {
+		source string
+		idx    uint32
+		ok     bool
+	}{
+		{"1", 1, true},
+		{"0", 0, true},
+		{"-1", 0, false},
+		{"'1'", 1, true},
+		{"'-1'", 0, false},
+		{"'a'", 0, false},
+		{"[1]", 1, true},
+		{"['1']", 1, true},
+		{"[1, 1]", 0, false},
+		{"{}", 0, false},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.source, func(t *testing.T) {
+			t.Parallel()
+			val, _ := ctx.RunScript(tt.source, "test.js")
+			idx, ok := val.ArrayIndex()
+			if ok != tt.ok {
+				t.Errorf("unexpected ok: expected %v, got %v", tt.ok, ok)
+			}
+			if idx != tt.idx {
+				t.Errorf("unexpected array index: expected %v, got %v", tt.idx, idx)
+			}
+		})
+	}
+
 }
 
 func TestValueIsXXX(t *testing.T) {

--- a/value_test.go
+++ b/value_test.go
@@ -101,7 +101,41 @@ func TestValueArrayIndex(t *testing.T) {
 			}
 		})
 	}
+}
 
+func TestValueInt32(t *testing.T) {
+	t.Parallel()
+	ctx, _ := v8go.NewContext(nil)
+	tests := [...]struct {
+		source   string
+		expected int32
+	}{
+		{"0", 0},
+		{"1", 1},
+		{"-1", -1},
+		{"'1'", 1},
+		{"'a'", 0},
+		{"[1]", 1},
+		{"[1,1]", 0},
+		{"Infinity", 0},
+		{"Number.MAX_SAFE_INTEGER", -1},
+		{"Number.MIN_SAFE_INTEGER", 1},
+		{"Number.NaN", 0},
+		{"2_147_483_647", 1<<31 - 1},
+		{"-2_147_483_648", -1 << 31},
+		{"2_147_483_648", -1 << 31}, // overflow
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.source, func(t *testing.T) {
+			t.Parallel()
+			val, _ := ctx.RunScript(tt.source, "test.js")
+			if i32 := val.Int32(); i32 != tt.expected {
+				t.Errorf("unexpected value: expected %v, got %v", tt.expected, i32)
+			}
+		})
+	}
 }
 
 func TestValueIsXXX(t *testing.T) {

--- a/value_test.go
+++ b/value_test.go
@@ -1,6 +1,7 @@
 package v8go_test
 
 import (
+	"math"
 	"reflect"
 	"runtime"
 	"testing"
@@ -114,6 +115,8 @@ func TestValueInt32(t *testing.T) {
 		{"1", 1},
 		{"-1", -1},
 		{"'1'", 1},
+		{"1.5", 1},
+		{"-1.5", -1},
 		{"'a'", 0},
 		{"[1]", 1},
 		{"[1,1]", 0},
@@ -149,6 +152,8 @@ func TestValueInteger(t *testing.T) {
 		{"1", 1},
 		{"-1", -1},
 		{"'1'", 1},
+		{"1.5", 1},
+		{"-1.5", -1},
 		{"'a'", 0},
 		{"[1]", 1},
 		{"[1,1]", 0},
@@ -168,6 +173,48 @@ func TestValueInteger(t *testing.T) {
 			val, _ := ctx.RunScript(tt.source, "test.js")
 			if i64 := val.Integer(); i64 != tt.expected {
 				t.Errorf("unexpected value: expected %v, got %v", tt.expected, i64)
+			}
+		})
+	}
+}
+
+func TestValueNumber(t *testing.T) {
+	t.Parallel()
+	ctx, _ := v8go.NewContext(nil)
+	tests := [...]struct {
+		source   string
+		expected float64
+	}{
+		{"0", 0},
+		{"1", 1},
+		{"-1", -1},
+		{"'1'", 1},
+		{"1.5", 1.5},
+		{"-1.5", -1.5},
+		{"'a'", math.NaN()},
+		{"[1]", 1},
+		{"[1,1]", math.NaN()},
+		{"Infinity", math.Inf(0)},
+		{"Number.MAX_VALUE", 1.7976931348623157e+308},
+		{"Number.MIN_VALUE", 5e-324},
+		{"Number.MAX_SAFE_INTEGER", 1<<53 - 1},
+		{"Number.NaN", math.NaN()},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.source, func(t *testing.T) {
+			t.Parallel()
+			val, _ := ctx.RunScript(tt.source, "test.js")
+			f64 := val.Number()
+			if math.IsNaN(tt.expected) {
+				if !math.IsNaN(f64) {
+					t.Errorf("unexpected value: expected NaN, got %v", f64)
+				}
+				return
+			}
+			if f64 != tt.expected {
+				t.Errorf("unexpected value: expected %v, got %v", tt.expected, f64)
 			}
 		})
 	}

--- a/value_test.go
+++ b/value_test.go
@@ -11,7 +11,7 @@ import (
 func TestValueString(t *testing.T) {
 	t.Parallel()
 	ctx, _ := v8go.NewContext(nil)
-	var tests = [...]struct {
+	tests := [...]struct {
 		name   string
 		source string
 		out    string
@@ -35,10 +35,42 @@ func TestValueString(t *testing.T) {
 	}
 }
 
+func TestValueBoolean(t *testing.T) {
+	t.Parallel()
+	ctx, _ := v8go.NewContext(nil)
+	tests := [...]struct {
+		source string
+		out    bool
+	}{
+		{"true", true},
+		{"false", false},
+		{"1", true},
+		{"0", false},
+		{"null", false},
+		{"undefined", false},
+		{"''", false},
+		{"'foo'", true},
+		{"() => {}", true},
+		{"{}", false},
+		{"{foo:'bar'}", true},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.source, func(t *testing.T) {
+			t.Parallel()
+			val, _ := ctx.RunScript(tt.source, "test.js")
+			if b := val.Boolean(); b != tt.out {
+				t.Errorf("unespected value: expected %v, got %v", tt.out, b)
+			}
+		})
+	}
+}
+
 func TestValueIsXXX(t *testing.T) {
 	t.Parallel()
 	iso, _ := v8go.NewIsolate()
-	var tests = []struct {
+	tests := [...]struct {
 		source string
 		assert func(*v8go.Value) bool
 	}{


### PR DESCRIPTION
This will enable getting of richer data types from the v8 value struct than just currently `string`

All the basic `ToXXX` methods have been implemented as defined here: 
https://v8.github.io/api/head/classv8_1_1Value.html#a838af7d16f0ce87b4411beb178383db4

However `ToBigInt()` and `ToObject()` have NOT yet been implemented. The reason is that `Object` represents everything that is not a primitive type: eg. Functions, Objects, Promises, Dates, Regex etc. Implementing all of the `Object` type would make this PR too large, and take quite a bit of time to implement.

Was hoping to include this PR in the next release, which already has a number of features people are waiting for to be released.

As such, I think it's best to un-export these methods (to not break the public API), get this PR merged, do a release and continue work on `Object` (and `BigInt`) in later PRs.
