### PR TITLE
Function Templates with callback functions in Go

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,12 +10,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Support for the BigInt value to the big.Int Go type
 - Create Object Templates with primitive values, including other Object Templates
 - Configure Object Template as the global object of any new Context
+- Function Templates with callbacks to Go
 
 ### Changed
 - NewContext() API has been improved to handle optional global object, as well as optional Isolate
 - Package error messages are now prefixed with `v8go` rather than the struct name
-
-### Changed
+- Deprecated `iso.Close()` in favor of `iso.Dispose()` to keep consistancy with the C++ API
 - Upgraded V8 to 8.8.278.14
 
 ## [v0.4.0] - 2021-01-14

--- a/context.go
+++ b/context.go
@@ -45,7 +45,7 @@ func NewContext(opt ...ContextOption) (*Context, error) {
 	}
 
 	if opts.gTmpl == nil {
-		opts.gTmpl = &ObjectTemplate{}
+		opts.gTmpl = &ObjectTemplate{&template{}}
 	}
 
 	ctx := &Context{

--- a/context_test.go
+++ b/context_test.go
@@ -61,6 +61,33 @@ func TestJSExceptions(t *testing.T) {
 	}
 }
 
+func TestContextRegistry(t *testing.T) {
+	t.Parallel()
+
+	ctx, _ := v8go.NewContext()
+	ctxref := ctx.Ref()
+
+	c1 := v8go.GetContext(ctxref)
+	if c1 != nil {
+		t.Error("expected context to be <nil>")
+	}
+
+	ctx.Register()
+	c2 := v8go.GetContext(ctxref)
+	if c2 == nil {
+		t.Error("expected context, but got <nil>")
+	}
+	if c2 != ctx {
+		t.Errorf("contexts should match %p != %p", c2, ctx)
+	}
+	ctx.Deregister()
+
+	c3 := v8go.GetContext(ctxref)
+	if c3 != nil {
+		t.Error("expected context to be <nil>")
+	}
+}
+
 func BenchmarkContext(b *testing.B) {
 	b.ReportAllocs()
 	vm, _ := v8go.NewIsolate()

--- a/export_test.go
+++ b/export_test.go
@@ -1,0 +1,29 @@
+package v8go
+
+// RegisterCallback is exported for testing only.
+func (i *Isolate) RegisterCallback(cb FunctionCallback) int {
+	return i.registerCallback(cb)
+}
+
+// GetCallback is exported for testing only.
+func (i *Isolate) GetCallback(ref int) FunctionCallback {
+	return i.getCallback(ref)
+}
+
+// Register is exported for testing only.
+func (c *Context) Register() {
+	c.register()
+}
+
+// Deregister is exported for testing only.
+func (c *Context) Deregister() {
+	c.deregister()
+}
+
+// GetContext is exported for testing only.
+var GetContext = getContext
+
+// Ref is exported for testing only.
+func (c *Context) Ref() int {
+	return c.ref
+}

--- a/function_template.go
+++ b/function_template.go
@@ -55,15 +55,15 @@ func NewFunctionTemplate(iso *Isolate, callback FunctionCallback) (*FunctionTemp
 }
 
 //export goFunctionCallback
-func goFunctionCallback(ctxref int, cbref int, args *C.ValuePtr, args_count int) C.ValuePtr {
+func goFunctionCallback(ctxref int, cbref int, args *C.ValuePtr, argsCount int) C.ValuePtr {
 	ctx := getContext(ctxref)
 
 	info := &FunctionCallbackInfo{
 		ctx:  ctx,
-		args: make([]*Value, args_count),
+		args: make([]*Value, argsCount),
 	}
 
-	argv := (*[1 << 30]C.ValuePtr)(unsafe.Pointer(args))[:args_count:args_count]
+	argv := (*[1 << 30]C.ValuePtr)(unsafe.Pointer(args))[:argsCount:argsCount]
 	for i, v := range argv {
 		val := &Value{ptr: v}
 		runtime.SetFinalizer(val, (*Value).finalizer)

--- a/function_template.go
+++ b/function_template.go
@@ -1,0 +1,59 @@
+package v8go
+
+// #include <stdlib.h>
+// #include "v8go.h"
+import "C"
+import (
+	"errors"
+	"runtime"
+	"unsafe"
+)
+
+type FunctionCallback func(info *FunctionCallbackInfo) *Value
+
+type FunctionCallbackInfo struct {
+	args []*Value
+}
+
+func (i *FunctionCallbackInfo) Args() []*Value {
+	return i.args
+}
+
+type FunctionTemplate struct {
+	*template
+}
+
+func NewFunctionTemplate(iso *Isolate, callback FunctionCallback) (*FunctionTemplate, error) {
+	if iso == nil {
+		return nil, errors.New("v8go: failed to create new FunctionTemplate: Isolate cannot be <nil>")
+	}
+
+	tmpl := &template{
+		ptr: C.NewFunctionTemplate(iso.ptr, unsafe.Pointer(&callback)),
+		iso: iso,
+	}
+	runtime.SetFinalizer(tmpl, (*template).finalizer)
+	return &FunctionTemplate{tmpl}, nil
+}
+
+//export goFunctionCallback
+func goFunctionCallback(callback unsafe.Pointer, args *C.ValuePtr, args_count int) {
+	callbackFunc := *(*FunctionCallback)(callback)
+
+	//TODO: This will need access to the Context to be able to create return values
+	info := &FunctionCallbackInfo{
+		args: make([]*Value, args_count),
+	}
+
+	argv := (*[1 << 30]C.ValuePtr)(unsafe.Pointer(args))[:args_count:args_count]
+	for i, v := range argv {
+		//TODO(rogchap): We must pass the current context and add this to the value struct
+		val := &Value{ptr: v}
+		runtime.SetFinalizer(val, (*Value).finalizer)
+		info.args[i] = val
+	}
+
+	rtnVal := callbackFunc(info)
+	//TODO: deal with the rtnVal
+	_ = rtnVal
+}

--- a/function_template.go
+++ b/function_template.go
@@ -40,6 +40,9 @@ func NewFunctionTemplate(iso *Isolate, callback FunctionCallback) (*FunctionTemp
 	if iso == nil {
 		return nil, errors.New("v8go: failed to create new FunctionTemplate: Isolate cannot be <nil>")
 	}
+	if callback == nil {
+		return nil, errors.New("v8go: failed to create new FunctionTemplate: FunctionCallback cannot be <nil>")
+	}
 
 	cbref := iso.registerCallback(callback)
 

--- a/function_template.go
+++ b/function_template.go
@@ -9,25 +9,33 @@ import (
 	"unsafe"
 )
 
+// FunctionCallback is a callback that is executed in Go when a function is executed in JS.
 type FunctionCallback func(info *FunctionCallbackInfo) *Value
 
+// FunctionCallbackInfo is the argument that is passed to a FunctionCallback.
 type FunctionCallbackInfo struct {
 	ctx  *Context
 	args []*Value
 }
 
+// Context is the current context that the callback is being executed in.
 func (i *FunctionCallbackInfo) Context() *Context {
 	return i.ctx
 }
 
+// Args returns a slice of the value arguments that are passed to the JS function.
 func (i *FunctionCallbackInfo) Args() []*Value {
 	return i.args
 }
 
+// FunctionTemplate is used to create functions at runtime.
+// There can only be one function created from a FunctionTemplate in a context.
+// The lifetime of the created function is equal to the lifetime of the context.
 type FunctionTemplate struct {
 	*template
 }
 
+// NewFunctionTemplate creates a FunctionTemplate for a given callback.
 func NewFunctionTemplate(iso *Isolate, callback FunctionCallback) (*FunctionTemplate, error) {
 	if iso == nil {
 		return nil, errors.New("v8go: failed to create new FunctionTemplate: Isolate cannot be <nil>")

--- a/function_template_test.go
+++ b/function_template_test.go
@@ -1,0 +1,29 @@
+package v8go_test
+
+import (
+	"fmt"
+	"testing"
+
+	"rogchap.com/v8go"
+)
+
+func TestFunctionTemplate(t *testing.T) {
+	//TODO: write proper tests
+
+	iso, _ := v8go.NewIsolate()
+	global, _ := v8go.NewObjectTemplate(iso)
+	printfn, _ := v8go.NewFunctionTemplate(iso, func(info *v8go.FunctionCallbackInfo) *v8go.Value {
+		fmt.Printf("Called print(): %+v\n", info.Args())
+		return nil
+	})
+	logfn, _ := v8go.NewFunctionTemplate(iso, func(info *v8go.FunctionCallbackInfo) *v8go.Value {
+		fmt.Printf("Called log(): %+v\n", info.Args())
+		return nil
+	})
+
+	global.Set("print", printfn)
+	global.Set("log", logfn)
+	ctx, _ := v8go.NewContext(iso, global)
+	ctx.RunScript("log();print('stuff', 'more', 4, 2n)", "")
+
+}

--- a/function_template_test.go
+++ b/function_template_test.go
@@ -11,8 +11,24 @@ import (
 )
 
 func TestFunctionTemplate(t *testing.T) {
-	//TODO: write proper tests
+	t.Parallel()
 
+	if _, err := v8go.NewFunctionTemplate(nil, func(*v8go.FunctionCallbackInfo) *v8go.Value { return nil }); err == nil {
+		t.Error("expected error but got <nil>")
+	}
+
+	iso, _ := v8go.NewIsolate()
+	if _, err := v8go.NewFunctionTemplate(iso, nil); err == nil {
+		t.Error("expected error but got <nil>")
+	}
+
+	fn, err := v8go.NewFunctionTemplate(iso, func(*v8go.FunctionCallbackInfo) *v8go.Value { return nil })
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if fn == nil {
+		t.Error("expected FunctionTemplate, but got <nil>")
+	}
 }
 
 func ExampleFunctionTemplate() {

--- a/function_template_test.go
+++ b/function_template_test.go
@@ -1,7 +1,9 @@
 package v8go_test
 
 import (
+	"context"
 	"fmt"
+	"net/http"
 	"testing"
 
 	"rogchap.com/v8go"
@@ -13,17 +15,33 @@ func TestFunctionTemplate(t *testing.T) {
 	iso, _ := v8go.NewIsolate()
 	global, _ := v8go.NewObjectTemplate(iso)
 	printfn, _ := v8go.NewFunctionTemplate(iso, func(info *v8go.FunctionCallbackInfo) *v8go.Value {
-		fmt.Printf("Called print(): %+v\n", info.Args())
-		return nil
+		args := info.Args()
+		fmt.Printf("Called print(): %+v\n", args)
+		val, _ := v8go.NewValue(iso, int32(len(args)))
+		return val
 	})
-	logfn, _ := v8go.NewFunctionTemplate(iso, func(info *v8go.FunctionCallbackInfo) *v8go.Value {
+	logfn, _ := v8go.NewFunctionTemplate(iso, func(info *v8go.FunctionCallbackInfo) (rtn *v8go.Value) {
 		fmt.Printf("Called log(): %+v\n", info.Args())
-		return nil
+		return
 	})
+	th := &thing{}
+	headfn, _ := v8go.NewFunctionTemplate(iso, th.cb)
 
 	global.Set("print", printfn)
 	global.Set("log", logfn)
+	global.Set("head", headfn)
 	ctx, _ := v8go.NewContext(iso, global)
-	ctx.RunScript("log();print('stuff', 'more', 4, 2n)", "")
+	val, _ := ctx.RunScript("head();log(print);print('stuff', 'more', 4, 2n)", "")
+	fmt.Printf("val = %+v\n", val)
+}
 
+type thing struct {
+	c context.Context
+	d *http.Client
+}
+
+func (t *thing) cb(info *v8go.FunctionCallbackInfo) *v8go.Value {
+	t.d = http.DefaultClient
+	go t.d.Head("http://rogchap.com")
+	return nil
 }

--- a/isolate.go
+++ b/isolate.go
@@ -86,7 +86,7 @@ func (i *Isolate) Dispose() {
 	i.finalizer()
 }
 
-// Close is Deprecated. Use `iso.Dispose()`.
+// Deprecated: use `iso.Dispose()`.
 func (i *Isolate) Close() {
 	i.Dispose()
 }

--- a/isolate.go
+++ b/isolate.go
@@ -4,7 +4,6 @@ package v8go
 import "C"
 
 import (
-	"runtime"
 	"sync"
 )
 
@@ -15,6 +14,10 @@ var v8once sync.Once
 // with many V8 contexts for execution.
 type Isolate struct {
 	ptr C.IsolatePtr
+
+	cbMutex sync.RWMutex
+	cbSeq   int
+	cbs     map[int]FunctionCallback
 }
 
 // HeapStatistics represents V8 isolate heap statistics
@@ -35,14 +38,18 @@ type HeapStatistics struct {
 // NewIsolate creates a new V8 isolate. Only one thread may access
 // a given isolate at a time, but different threads may access
 // different isolates simultaneously.
+// When an isolate is no longer used its resources should be freed
+// by calling iso.Dispose().
 // An *Isolate can be used as a v8go.ContextOption to create a new
 // Context, rather than creating a new default Isolate.
 func NewIsolate() (*Isolate, error) {
 	v8once.Do(func() {
 		C.Init()
 	})
-	iso := &Isolate{C.NewIsolate()}
-	runtime.SetFinalizer(iso, (*Isolate).finalizer)
+	iso := &Isolate{
+		ptr: C.NewIsolate(),
+		cbs: make(map[int]FunctionCallback),
+	}
 	// TODO: [RC] catch any C++ exceptions and return as error
 	return iso, nil
 }
@@ -72,17 +79,32 @@ func (i *Isolate) GetHeapStatistics() HeapStatistics {
 	}
 }
 
-func (i *Isolate) finalizer() {
+// Dispose will dispose the Isolate VM; subsequent calls will panic.
+func (i *Isolate) Dispose() {
 	C.IsolateDispose(i.ptr)
 	i.ptr = nil
-	runtime.SetFinalizer(i, nil)
 }
 
-// Close will dispose the Isolate VM; subsequent calls will panic
+// Close is Deprecated. Use `iso.Dispose()`.
 func (i *Isolate) Close() {
-	i.finalizer()
+	i.Dispose()
 }
 
 func (i *Isolate) apply(opts *contextOptions) {
 	opts.iso = i
+}
+
+func (i *Isolate) registerCallback(cb FunctionCallback) int {
+	i.cbMutex.Lock()
+	i.cbSeq++
+	ref := i.cbSeq
+	i.cbs[ref] = cb
+	i.cbMutex.Unlock()
+	return ref
+}
+
+func (i *Isolate) getCallback(ref int) FunctionCallback {
+	i.cbMutex.RLock()
+	defer i.cbMutex.RUnlock()
+	return i.cbs[ref]
 }

--- a/isolate_test.go
+++ b/isolate_test.go
@@ -52,6 +52,26 @@ func TestGetHeapStatistics(t *testing.T) {
 	}
 }
 
+func TestCallbackRegistry(t *testing.T) {
+	t.Parallel()
+
+	iso, _ := v8go.NewIsolate()
+	cb := func(*v8go.FunctionCallbackInfo) *v8go.Value { return nil }
+
+	cb0 := iso.GetCallback(0)
+	if cb0 != nil {
+		t.Error("expected callback function to be <nil>")
+	}
+	ref1 := iso.RegisterCallback(cb)
+	if ref1 != 1 {
+		t.Errorf("expected callback ref == 1, got %d", ref1)
+	}
+	cb1 := iso.GetCallback(1)
+	if fmt.Sprintf("%p", cb1) != fmt.Sprintf("%p", cb) {
+		t.Errorf("unexpected callback function; want %p, got %p", cb, cb1)
+	}
+}
+
 func BenchmarkIsolateInitialization(b *testing.B) {
 	b.ReportAllocs()
 	for n := 0; n < b.N; n++ {

--- a/isolate_test.go
+++ b/isolate_test.go
@@ -43,8 +43,8 @@ func TestGetHeapStatistics(t *testing.T) {
 
 	hs := iso.GetHeapStatistics()
 
-	if hs.NumberOfNativeContexts != 2 {
-		t.Error("expect NumberOfNativeContexts return 2, got", hs.NumberOfNativeContexts)
+	if hs.NumberOfNativeContexts != 3 {
+		t.Error("expect NumberOfNativeContexts return 3, got", hs.NumberOfNativeContexts)
 	}
 
 	if hs.NumberOfDetachedContexts != 0 {

--- a/object_template.go
+++ b/object_template.go
@@ -3,13 +3,6 @@ package v8go
 // #include <stdlib.h>
 // #include "v8go.h"
 import "C"
-import (
-	"errors"
-	"fmt"
-	"math/big"
-	"runtime"
-	"unsafe"
-)
 
 // PropertyAttribute are the attribute flags for a property on an Object.
 // Typical usage when setting an Object or TemplateObject property, and
@@ -30,64 +23,19 @@ const (
 // ObjectTemplate is used to create objects at runtime.
 // Properties added to an ObjectTemplate are added to each object created from the ObjectTemplate.
 type ObjectTemplate struct {
-	ptr C.ObjectTemplatePtr
-	iso *Isolate
+	*template
 }
 
 // NewObjectTemplate creates a new ObjectTemplate.
 // The *ObjectTemplate can be used as a v8go.ContextOption to create a global object in a Context.
 func NewObjectTemplate(iso *Isolate) (*ObjectTemplate, error) {
-	if iso == nil {
-		return nil, errors.New("v8go: failed to create new ObjectTemplate: Isolate cannot be <nil>")
+	tmpl, err := newTemplate(iso)
+	if err != nil {
+		return nil, err
 	}
-	ob := &ObjectTemplate{
-		ptr: C.NewObjectTemplate(iso.ptr),
-		iso: iso,
-	}
-	runtime.SetFinalizer(ob, (*ObjectTemplate).finalizer)
-	return ob, nil
-}
-
-// Set adds a property to each instance created by this template.
-// The property must be defined either as a primitive value, or a template.
-// If the value passed is a Go supported primitive (string, int32, uint32, int64, uint64, float64, big.Int)
-// then a value will be created and set as the value property.
-func (o *ObjectTemplate) Set(name string, val interface{}, attributes ...PropertyAttribute) error {
-	cname := C.CString(name)
-	defer C.free(unsafe.Pointer(cname))
-
-	var attrs PropertyAttribute
-	for _, a := range attributes {
-		attrs |= a
-	}
-
-	switch v := val.(type) {
-	case string, int32, uint32, int64, uint64, float64, bool, *big.Int:
-		newVal, err := NewValue(o.iso, v)
-		if err != nil {
-			return fmt.Errorf("v8go: unable to create new value: %v", err)
-		}
-		C.ObjectTemplateSetValue(o.ptr, cname, newVal.ptr, C.int(attrs))
-	case *ObjectTemplate:
-		C.ObjectTemplateSetObjectTemplate(o.ptr, cname, v.ptr, C.int(attrs))
-	case *Value:
-		if v.IsObject() || v.IsExternal() {
-			return errors.New("v8go: unsupported property: value type must be a primitive or use a template")
-		}
-		C.ObjectTemplateSetValue(o.ptr, cname, v.ptr, C.int(attrs))
-	default:
-		return fmt.Errorf("v8go: unsupported property type `%T`, must be one of string, int32, uint32, int64, uint64, float64, *big.Int, *v8go.Value or *v8go.ObjectTemplate", v)
-	}
-
-	return nil
+	return &ObjectTemplate{tmpl}, nil
 }
 
 func (o *ObjectTemplate) apply(opts *contextOptions) {
 	opts.gTmpl = o
-}
-
-func (o *ObjectTemplate) finalizer() {
-	C.ObjectTemplateDispose(o.ptr)
-	o.ptr = nil
-	runtime.SetFinalizer(o, nil)
 }

--- a/object_template.go
+++ b/object_template.go
@@ -3,6 +3,10 @@ package v8go
 // #include <stdlib.h>
 // #include "v8go.h"
 import "C"
+import (
+	"errors"
+	"runtime"
+)
 
 // PropertyAttribute are the attribute flags for a property on an Object.
 // Typical usage when setting an Object or TemplateObject property, and
@@ -29,10 +33,15 @@ type ObjectTemplate struct {
 // NewObjectTemplate creates a new ObjectTemplate.
 // The *ObjectTemplate can be used as a v8go.ContextOption to create a global object in a Context.
 func NewObjectTemplate(iso *Isolate) (*ObjectTemplate, error) {
-	tmpl, err := newTemplate(iso)
-	if err != nil {
-		return nil, err
+	if iso == nil {
+		return nil, errors.New("v8go: failed to create new ObjectTemplate: Isolate cannot be <nil>")
 	}
+
+	tmpl := &template{
+		ptr: C.NewObjectTemplate(iso.ptr),
+		iso: iso,
+	}
+	runtime.SetFinalizer(tmpl, (*template).finalizer)
 	return &ObjectTemplate{tmpl}, nil
 }
 

--- a/template.go
+++ b/template.go
@@ -52,8 +52,8 @@ func (t *template) Set(name string, val interface{}, attributes ...PropertyAttri
 	return nil
 }
 
-func (o *template) finalizer() {
-	C.TemplateFree(o.ptr)
-	o.ptr = nil
-	runtime.SetFinalizer(o, nil)
+func (t *template) finalizer() {
+	C.TemplateFree(t.ptr)
+	t.ptr = nil
+	runtime.SetFinalizer(t, nil)
 }

--- a/template.go
+++ b/template.go
@@ -38,6 +38,8 @@ func (t *template) Set(name string, val interface{}, attributes ...PropertyAttri
 		C.TemplateSetValue(t.ptr, cname, newVal.ptr, C.int(attrs))
 	case *ObjectTemplate:
 		C.TemplateSetTemplate(t.ptr, cname, v.ptr, C.int(attrs))
+	case *FunctionTemplate:
+		C.TemplateSetTemplate(t.ptr, cname, v.ptr, C.int(attrs))
 	case *Value:
 		if v.IsObject() || v.IsExternal() {
 			return errors.New("v8go: unsupported property: value type must be a primitive or use a template")

--- a/template.go
+++ b/template.go
@@ -1,0 +1,70 @@
+package v8go
+
+// #include <stdlib.h>
+// #include "v8go.h"
+import "C"
+import (
+	"errors"
+	"fmt"
+	"math/big"
+	"runtime"
+	"unsafe"
+)
+
+type template struct {
+	ptr C.ObjectTemplatePtr
+	iso *Isolate
+}
+
+func newTemplate(iso *Isolate) (*template, error) {
+	if iso == nil {
+		return nil, errors.New("v8go: failed to create new Template: Isolate cannot be <nil>")
+	}
+
+	ob := &template{
+		ptr: C.NewObjectTemplate(iso.ptr),
+		iso: iso,
+	}
+	runtime.SetFinalizer(ob, (*template).finalizer)
+	return ob, nil
+}
+
+// Set adds a property to each instance created by this template.
+// The property must be defined either as a primitive value, or a template.
+// If the value passed is a Go supported primitive (string, int32, uint32, int64, uint64, float64, big.Int)
+// then a value will be created and set as the value property.
+func (t *template) Set(name string, val interface{}, attributes ...PropertyAttribute) error {
+	cname := C.CString(name)
+	defer C.free(unsafe.Pointer(cname))
+
+	var attrs PropertyAttribute
+	for _, a := range attributes {
+		attrs |= a
+	}
+
+	switch v := val.(type) {
+	case string, int32, uint32, int64, uint64, float64, bool, *big.Int:
+		newVal, err := NewValue(t.iso, v)
+		if err != nil {
+			return fmt.Errorf("v8go: unable to create new value: %v", err)
+		}
+		C.ObjectTemplateSetValue(t.ptr, cname, newVal.ptr, C.int(attrs))
+	case *ObjectTemplate:
+		C.ObjectTemplateSetObjectTemplate(t.ptr, cname, v.ptr, C.int(attrs))
+	case *Value:
+		if v.IsObject() || v.IsExternal() {
+			return errors.New("v8go: unsupported property: value type must be a primitive or use a template")
+		}
+		C.ObjectTemplateSetValue(t.ptr, cname, v.ptr, C.int(attrs))
+	default:
+		return fmt.Errorf("v8go: unsupported property type `%T`, must be one of string, int32, uint32, int64, uint64, float64, *big.Int, *v8go.Value, *v8go.ObjectTemplate or *v8go.FunctionTemplate", v)
+	}
+
+	return nil
+}
+
+func (o *template) finalizer() {
+	C.ObjectTemplateDispose(o.ptr)
+	o.ptr = nil
+	runtime.SetFinalizer(o, nil)
+}

--- a/template.go
+++ b/template.go
@@ -53,7 +53,7 @@ func (t *template) Set(name string, val interface{}, attributes ...PropertyAttri
 }
 
 func (o *template) finalizer() {
-	C.TemplateDispose(o.ptr)
+	C.TemplateFree(o.ptr)
 	o.ptr = nil
 	runtime.SetFinalizer(o, nil)
 }

--- a/v8go.h
+++ b/v8go.h
@@ -49,13 +49,23 @@ extern void IsolateDispose(IsolatePtr ptr);
 extern void IsolateTerminateExecution(IsolatePtr ptr);
 extern IsolateHStatistics IsolationGetHeapStatistics(IsolatePtr ptr);
 
-extern ContextPtr NewContext(IsolatePtr iso_ptr, TemplatePtr global_template_ptr, int ref);
+extern ContextPtr NewContext(IsolatePtr iso_ptr,
+                             TemplatePtr global_template_ptr,
+                             int ref);
 extern void ContextFree(ContextPtr ptr);
-extern RtnValue RunScript(ContextPtr ctx_ptr, const char* source, const char* origin);
+extern RtnValue RunScript(ContextPtr ctx_ptr,
+                          const char* source,
+                          const char* origin);
 
 extern void TemplateFree(TemplatePtr ptr);
-extern void TemplateSetValue(TemplatePtr ptr, const char* name, ValuePtr val_ptr, int attributes);
-extern void TemplateSetTemplate(TemplatePtr ptr, const char* name, TemplatePtr obj_ptr, int attributes);
+extern void TemplateSetValue(TemplatePtr ptr,
+                             const char* name,
+                             ValuePtr val_ptr,
+                             int attributes);
+extern void TemplateSetTemplate(TemplatePtr ptr,
+                                const char* name,
+                                TemplatePtr obj_ptr,
+                                int attributes);
 
 extern TemplatePtr NewObjectTemplate(IsolatePtr iso_ptr);
 extern TemplatePtr NewFunctionTemplate(IsolatePtr iso_ptr, int callback_ref);
@@ -67,7 +77,10 @@ extern ValuePtr NewValueBoolean(IsolatePtr iso_ptr, int v);
 extern ValuePtr NewValueNumber(IsolatePtr iso_ptr, double v);
 extern ValuePtr NewValueBigInt(IsolatePtr iso_ptr, int64_t v);
 extern ValuePtr NewValueBigIntFromUnsigned(IsolatePtr iso_ptr, uint64_t v);
-extern ValuePtr NewValueBigIntFromWords(IsolatePtr iso_ptr, int sign_bit, int word_count, const uint64_t* words);
+extern ValuePtr NewValueBigIntFromWords(IsolatePtr iso_ptr,
+                                        int sign_bit,
+                                        int word_count,
+                                        const uint64_t* words);
 extern void ValueFree(ValuePtr ptr);
 const char* ValueToString(ValuePtr ptr);
 const uint32_t* ValueToArrayIndex(ValuePtr ptr);

--- a/v8go.h
+++ b/v8go.h
@@ -10,7 +10,7 @@ extern "C" {
 typedef void* IsolatePtr;
 typedef void* ContextPtr;
 typedef void* ValuePtr;
-typedef void* ObjectTemplatePtr;
+typedef void* TemplatePtr;
 
 typedef struct {
   const char* msg;
@@ -49,20 +49,15 @@ extern void IsolateDispose(IsolatePtr ptr);
 extern void IsolateTerminateExecution(IsolatePtr ptr);
 extern IsolateHStatistics IsolationGetHeapStatistics(IsolatePtr ptr);
 
-extern ContextPtr NewContext(IsolatePtr iso_ptr,
-                             ObjectTemplatePtr global_template_ptr);
+extern ContextPtr NewContext(IsolatePtr iso_ptr, TemplatePtr global_template_ptr);
 extern void ContextDispose(ContextPtr ptr);
-extern RtnValue RunScript(ContextPtr ctx_ptr,
-                          const char* source,
-                          const char* origin);
+extern RtnValue RunScript(ContextPtr ctx_ptr, const char* source, const char* origin);
 
-extern ObjectTemplatePtr NewObjectTemplate(IsolatePtr iso_ptr);
-extern void ObjectTemplateDispose(ObjectTemplatePtr ptr);
-extern void ObjectTemplateSetValue(ObjectTemplatePtr ptr,
-                              const char* name,
-                              ValuePtr val_ptr,
-                              int attributes);
-extern void ObjectTemplateSetObjectTemplate(ObjectTemplatePtr ptr, const char* name, ObjectTemplatePtr obj_ptr, int attributes);
+extern void TemplateDispose(TemplatePtr ptr);
+extern void TemplateSetValue(TemplatePtr ptr, const char* name, ValuePtr val_ptr, int attributes);
+extern void TemplateSetTemplate(TemplatePtr ptr, const char* name, TemplatePtr obj_ptr, int attributes);
+
+extern TemplatePtr NewObjectTemplate(IsolatePtr iso_ptr);
 
 extern ValuePtr NewValueInteger(IsolatePtr iso_ptr, int32_t v);
 extern ValuePtr NewValueIntegerFromUnsigned(IsolatePtr iso_ptr, uint32_t v);

--- a/v8go.h
+++ b/v8go.h
@@ -49,16 +49,16 @@ extern void IsolateDispose(IsolatePtr ptr);
 extern void IsolateTerminateExecution(IsolatePtr ptr);
 extern IsolateHStatistics IsolationGetHeapStatistics(IsolatePtr ptr);
 
-extern ContextPtr NewContext(IsolatePtr iso_ptr, TemplatePtr global_template_ptr);
-extern void ContextDispose(ContextPtr ptr);
+extern ContextPtr NewContext(IsolatePtr iso_ptr, TemplatePtr global_template_ptr, int ref);
+extern void ContextFree(ContextPtr ptr);
 extern RtnValue RunScript(ContextPtr ctx_ptr, const char* source, const char* origin);
 
-extern void TemplateDispose(TemplatePtr ptr);
+extern void TemplateFree(TemplatePtr ptr);
 extern void TemplateSetValue(TemplatePtr ptr, const char* name, ValuePtr val_ptr, int attributes);
 extern void TemplateSetTemplate(TemplatePtr ptr, const char* name, TemplatePtr obj_ptr, int attributes);
 
 extern TemplatePtr NewObjectTemplate(IsolatePtr iso_ptr);
-extern TemplatePtr NewFunctionTemplate(IsolatePtr iso_ptr, void* callback);
+extern TemplatePtr NewFunctionTemplate(IsolatePtr iso_ptr, int callback_ref);
 
 extern ValuePtr NewValueInteger(IsolatePtr iso_ptr, int32_t v);
 extern ValuePtr NewValueIntegerFromUnsigned(IsolatePtr iso_ptr, uint32_t v);
@@ -68,7 +68,7 @@ extern ValuePtr NewValueNumber(IsolatePtr iso_ptr, double v);
 extern ValuePtr NewValueBigInt(IsolatePtr iso_ptr, int64_t v);
 extern ValuePtr NewValueBigIntFromUnsigned(IsolatePtr iso_ptr, uint64_t v);
 extern ValuePtr NewValueBigIntFromWords(IsolatePtr iso_ptr, int sign_bit, int word_count, const uint64_t* words);
-extern void ValueDispose(ValuePtr ptr);
+extern void ValueFree(ValuePtr ptr);
 const char* ValueToString(ValuePtr ptr);
 const uint32_t* ValueToArrayIndex(ValuePtr ptr);
 int ValueToBoolean(ValuePtr ptr);

--- a/v8go.h
+++ b/v8go.h
@@ -58,6 +58,7 @@ extern void TemplateSetValue(TemplatePtr ptr, const char* name, ValuePtr val_ptr
 extern void TemplateSetTemplate(TemplatePtr ptr, const char* name, TemplatePtr obj_ptr, int attributes);
 
 extern TemplatePtr NewObjectTemplate(IsolatePtr iso_ptr);
+extern TemplatePtr NewFunctionTemplate(IsolatePtr iso_ptr, void* callback);
 
 extern ValuePtr NewValueInteger(IsolatePtr iso_ptr, int32_t v);
 extern ValuePtr NewValueIntegerFromUnsigned(IsolatePtr iso_ptr, uint32_t v);

--- a/value.go
+++ b/value.go
@@ -496,7 +496,7 @@ func (v *Value) IsModuleNamespaceObject() bool {
 }
 
 func (v *Value) finalizer() {
-	C.ValueDispose(v.ptr)
+	C.ValueFree(v.ptr)
 	v.ptr = nil
 	runtime.SetFinalizer(v, nil)
 }

--- a/value.go
+++ b/value.go
@@ -74,12 +74,14 @@ func NewValue(iso *Isolate, val interface{}) (*Value, error) {
 			rtnVal = &Value{
 				ptr: C.NewValueBigInt(iso.ptr, C.int64_t(v.Int64())),
 			}
+			break
 		}
 
 		if v.IsUint64() {
 			rtnVal = &Value{
 				ptr: C.NewValueBigIntFromUnsigned(iso.ptr, C.uint64_t(v.Uint64())),
 			}
+			break
 		}
 
 		var sign, count int

--- a/value_test.go
+++ b/value_test.go
@@ -333,8 +333,6 @@ func TestValueBigInt(t *testing.T) {
 			ctx, _ := v8go.NewContext(iso)
 			val, _ := ctx.RunScript(tt.source, "test.js")
 			b := val.BigInt()
-			fmt.Printf("b = %+v\n", b)
-			fmt.Printf("tt = %+v\n", tt)
 			if b == nil && tt.expected != nil {
 				t.Errorf("uexpected <nil> value")
 				return


### PR DESCRIPTION
Basic `FunctionTemplate` support, which allows global functions that callback to Go functions:
```go
iso, _ := v8go.NewIsolate()
global, _ := v8go.NewObjectTemplate(iso)
printfn, _ := v8go.NewFunctionTemplate(iso, func(info *v8go.FunctionCallbackInfo) *v8go.Value {
	fmt.Printf("%+v\n", info.Args())
	return nil
})
global.Set("print", printfn, v8go.ReadOnly)
ctx, _ := v8go.NewContext(iso, global)
ctx.RunScript("print('foo', 'bar', 0, 1)", "")
// Output:
// [foo bar 0 1]
```

Due to the complexities of Go -> C -> Go there are two registries:

1) Callback registry attached to the Isolate
2) A global registry for the Context

To make sure that created Contexts can be GC'd we have a register/deregister surrounding script execution; other wise a `map[int]*Context` would never GC 