### PR TITLE
BSD-style licence

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,21 +1,27 @@
-The MIT License (MIT)
+Copyright (c) 2019 Roger Chapman and the v8go contributors.
+All rights reserved.
 
-Copyright (c) 2019-present Roger Chapman. All Rights Reserved.
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
 
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
+   1. Redistributions of source code must retain the above copyright notice,
+      this list of conditions and the following disclaimer.
 
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
+   2. Redistributions in binary form must reproduce the above copyright notice,
+      this list of conditions and the following disclaimer in the documentation
+      and/or other materials provided with the distribution.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
+   3. Neither the name of the copyright holder nor the names of its
+      contributors may be used to endorse or promote products derived from
+      this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/cgo.go
+++ b/cgo.go
@@ -1,3 +1,7 @@
+// Copyright 2019 Roger Chapman and the v8go contributors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 package v8go
 
 //go:generate clang-format -i --verbose -style=Chromium v8go.h v8go.cc

--- a/context.go
+++ b/context.go
@@ -1,3 +1,7 @@
+// Copyright 2019 Roger Chapman and the v8go contributors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 package v8go
 
 // #include <stdlib.h>

--- a/context_test.go
+++ b/context_test.go
@@ -1,3 +1,7 @@
+// Copyright 2019 Roger Chapman and the v8go contributors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 package v8go_test
 
 import (

--- a/errors.go
+++ b/errors.go
@@ -1,3 +1,7 @@
+// Copyright 2019 Roger Chapman and the v8go contributors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 package v8go
 
 import (

--- a/errors_test.go
+++ b/errors_test.go
@@ -1,3 +1,7 @@
+// Copyright 2019 Roger Chapman and the v8go contributors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 package v8go_test
 
 import (

--- a/export_test.go
+++ b/export_test.go
@@ -1,3 +1,7 @@
+// Copyright 2019 Roger Chapman and the v8go contributors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 package v8go
 
 // RegisterCallback is exported for testing only.

--- a/function_template.go
+++ b/function_template.go
@@ -1,3 +1,7 @@
+// Copyright 2021 Roger Chapman and the v8go contributors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 package v8go
 
 // #include <stdlib.h>

--- a/function_template_test.go
+++ b/function_template_test.go
@@ -1,3 +1,7 @@
+// Copyright 2021 Roger Chapman and the v8go contributors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 package v8go_test
 
 import (

--- a/isolate.go
+++ b/isolate.go
@@ -1,3 +1,7 @@
+// Copyright 2019 Roger Chapman and the v8go contributors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 package v8go
 
 // #include "v8go.h"

--- a/isolate_test.go
+++ b/isolate_test.go
@@ -1,3 +1,7 @@
+// Copyright 2019 Roger Chapman and the v8go contributors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 package v8go_test
 
 import (

--- a/json.go
+++ b/json.go
@@ -1,3 +1,7 @@
+// Copyright 2021 Roger Chapman and the v8go contributors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 package v8go
 
 // #include <stdlib.h>

--- a/json_test.go
+++ b/json_test.go
@@ -1,3 +1,7 @@
+// Copyright 2021 Roger Chapman and the v8go contributors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 package v8go_test
 
 import (

--- a/object_template.go
+++ b/object_template.go
@@ -1,3 +1,7 @@
+// Copyright 2020 Roger Chapman and the v8go contributors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 package v8go
 
 // #include <stdlib.h>

--- a/object_template_test.go
+++ b/object_template_test.go
@@ -1,3 +1,7 @@
+// Copyright 2020 Roger Chapman and the v8go contributors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 package v8go_test
 
 import (

--- a/template.go
+++ b/template.go
@@ -1,3 +1,7 @@
+// Copyright 2021 Roger Chapman and the v8go contributors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 package v8go
 
 // #include <stdlib.h>

--- a/v8go.cc
+++ b/v8go.cc
@@ -1,3 +1,7 @@
+// Copyright 2019 Roger Chapman and the v8go contributors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 #include "v8go.h"
 
 #include <stdio.h>

--- a/v8go.go
+++ b/v8go.go
@@ -1,3 +1,7 @@
+// Copyright 2019 Roger Chapman and the v8go contributors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 /*
 Package v8go provides an API to execute JavaScript.
 */

--- a/v8go.h
+++ b/v8go.h
@@ -1,3 +1,7 @@
+// Copyright 2019 Roger Chapman and the v8go contributors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 #ifndef V8GO_H
 #define V8GO_H
 #ifdef __cplusplus

--- a/v8go_test.go
+++ b/v8go_test.go
@@ -1,3 +1,7 @@
+// Copyright 2019 Roger Chapman and the v8go contributors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 package v8go_test
 
 import (

--- a/value.go
+++ b/value.go
@@ -1,3 +1,7 @@
+// Copyright 2019 Roger Chapman and the v8go contributors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 package v8go
 
 // #include <stdlib.h>

--- a/value_test.go
+++ b/value_test.go
@@ -1,3 +1,7 @@
+// Copyright 2019 Roger Chapman and the v8go contributors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 package v8go_test
 
 import (


### PR DESCRIPTION
Updates the LICENSE for v8go to be **3 Clause BSD** from MIT
BSD has a minute difference to MIT and are basically "the same" (but I'm not a lawyer so... 🤷‍♂️)

This keeps the license in-line with the V8 library (and Go itself) that also has a the 3 Clause BSD license. 