### PR TITLE
Extend Value into the Object type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,12 +11,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Create Object Templates with primitive values, including other Object Templates
 - Configure Object Template as the global object of any new Context
 - Function Templates with callbacks to Go
+- Value to Object type, including Get/Set/Has/Delete methods
+- Get Global Object from the Context
+- Convert a Object Template to an instance of an Object
 
 ### Changed
 - NewContext() API has been improved to handle optional global object, as well as optional Isolate
 - Package error messages are now prefixed with `v8go` rather than the struct name
 - Deprecated `iso.Close()` in favor of `iso.Dispose()` to keep consistancy with the C++ API
 - Upgraded V8 to 8.8.278.14
+- Licence BSD 3-Clause (same as V8 and Go)
 
 ## [v0.4.0] - 2021-01-14
 

--- a/context.go
+++ b/context.go
@@ -102,6 +102,20 @@ func (c *Context) RunScript(source string, origin string) (*Value, error) {
 	return getValue(c, rtn), getError(rtn)
 }
 
+// Global returns the global proxy object.
+// Global proxy object is a thin wrapper whose prototype points to actual
+// context's global object with the properties like Object, etc. This is
+// done that way for security reasons.
+// Please note that changes to global proxy object prototype most probably
+// would break the VM — V8 expects only global object as a prototype of
+// global proxy object.
+func (c *Context) Global() *Object {
+	valPtr := C.ContextGlobal(c.ptr)
+	v := &Value{valPtr, c}
+	runtime.SetFinalizer(v, (*Value).finalizer)
+	return &Object{v}
+}
+
 // Close will dispose the context and free the memory.
 func (c *Context) Close() {
 	c.finalizer()

--- a/json.go
+++ b/json.go
@@ -22,8 +22,8 @@ func JSONParse(ctx *Context, str string) (*Value, error) {
 }
 
 // JSONStringify tries to stringify the JSON-serializable object value and returns it as string.
-func JSONStringify(ctx *Context, val *Value) (string, error) {
-	if val == nil {
+func JSONStringify(ctx *Context, val Valuer) (string, error) {
+	if val.value() == nil {
 		return "", errors.New("v8go: Value is required")
 	}
 	// If a nil context is passed we'll use the context/isolate that created the value.
@@ -32,7 +32,7 @@ func JSONStringify(ctx *Context, val *Value) (string, error) {
 		ctxPtr = ctx.ptr
 	}
 
-	str := C.JSONStringify(ctxPtr, val.ptr)
+	str := C.JSONStringify(ctxPtr, val.value().ptr)
 	defer C.free(unsafe.Pointer(str))
 	return C.GoString(str), nil
 }

--- a/json.go
+++ b/json.go
@@ -27,7 +27,7 @@ func JSONParse(ctx *Context, str string) (*Value, error) {
 
 // JSONStringify tries to stringify the JSON-serializable object value and returns it as string.
 func JSONStringify(ctx *Context, val Valuer) (string, error) {
-	if val.value() == nil {
+	if val == nil || val.value() == nil {
 		return "", errors.New("v8go: Value is required")
 	}
 	// If a nil context is passed we'll use the context/isolate that created the value.

--- a/json_test.go
+++ b/json_test.go
@@ -29,6 +29,15 @@ func TestJSONParse(t *testing.T) {
 	}
 }
 
+func TestJSONStringify(t *testing.T) {
+	t.Parallel()
+
+	ctx, _ := v8go.NewContext()
+	if _, err := v8go.JSONStringify(ctx, nil); err == nil {
+		t.Error("expected error but got <nil>")
+	}
+}
+
 func ExampleJSONParse() {
 	ctx, _ := v8go.NewContext()
 	val, _ := v8go.JSONParse(ctx, `{"foo": "bar"}`)

--- a/json_test.go
+++ b/json_test.go
@@ -23,7 +23,6 @@ func TestJSONParse(t *testing.T) {
 	if _, ok := err.(*v8go.JSError); !ok {
 		t.Errorf("expected error to be of type JSError, got: %T", err)
 	}
-
 }
 
 func ExampleJSONParse() {

--- a/object.go
+++ b/object.go
@@ -1,3 +1,7 @@
+// Copyright 2021 Roger Chapman and the v8go contributors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 package v8go
 
 // #include <stdlib.h>

--- a/object.go
+++ b/object.go
@@ -1,5 +1,44 @@
 package v8go
 
+// #include <stdlib.h>
+// #include "v8go.h"
+import "C"
+import (
+	"errors"
+	"fmt"
+	"math/big"
+	"unsafe"
+)
+
 type Object struct {
 	*Value
+}
+
+// Set will set a property on the Object to a given value.
+// Supports all value types, eg: Object, Array, Date, Set, Map etc
+// If the value passed is a Go supported primitive (string, int32, uint32, int64, uint64, float64, big.Int)
+// then a *Value will be created and set as the value property.
+func (o *Object) Set(key string, val interface{}) error {
+	if o.ctx == nil {
+		return errors.New("v8go: unable to set property: Object has no Context")
+	}
+	cname := C.CString(name)
+	defer C.free(unsafe.Pointer(cname))
+
+	var value *Value
+	switch v := val.(type) {
+	case string, int32, uint32, int64, uint64, float64, bool, *big.Int:
+		var err error
+		if value, err = NewValue(o.ctx.iso, v); err != nil {
+			return fmt.Errorf("v8go: unable to create new value: %v", err)
+		}
+	case valuer:
+		value = v.value()
+	default:
+		return fmt.Errorf("v8go: unsupported object property type `%T`", v)
+	}
+
+	C.ObjectSet(o.ptr, cname, value)
+
+	return nil
 }

--- a/object.go
+++ b/object.go
@@ -1,0 +1,5 @@
+package v8go
+
+type Object struct {
+	*Value
+}

--- a/object.go
+++ b/object.go
@@ -53,12 +53,51 @@ func set(o *Object, key string, idx uint32, val interface{}) error {
 	}
 
 	if len(key) > 0 {
-		cname := C.CString(key)
-		defer C.free(unsafe.Pointer(cname))
-		C.ObjectSet(o.ptr, cname, value.ptr)
+		ckey := C.CString(key)
+		defer C.free(unsafe.Pointer(ckey))
+		C.ObjectSet(o.ptr, ckey, value.ptr)
 		return nil
 	}
 
 	C.ObjectSetIdx(o.ptr, C.uint32_t(idx), value.ptr)
 	return nil
+}
+
+// Get tries to get a Value for a given Object property key.
+func (o *Object) Get(key string) (*Value, error) {
+	if o.ctx == nil {
+		return nil, errors.New("v8go: unable to set property: Object has no Context")
+	}
+	ckey := C.CString(key)
+	defer C.free(unsafe.Pointer(ckey))
+
+	rtn := C.ObjectGet(o.ptr, ckey)
+	return getValue(o.ctx, rtn), getError(rtn)
+}
+
+// GetIdx tries to get a Value at a give Object index.
+func (o *Object) GetIdx(idx uint32) (*Value, error) {
+	rtn := C.ObjectGetIdx(o.ptr, C.uint32_t(idx))
+	return getValue(o.ctx, rtn), getError(rtn)
+}
+
+// Has calls the abstract operation HasProperty(O, P) described in ECMA-262, 7.3.10.
+// Returns true, if the object has the property, either own or on the prototype chain.
+func (o *Object) Has(key string) bool {
+	panic("not implemented")
+}
+
+// HasIdx returns true if the object has a value at the given index.
+func (o *Object) HasIdx(idx uint32) bool {
+	panic("not implemented")
+}
+
+// Delete returns true if successful in deleting a named property on the object.
+func (o *Object) Delete(key string) bool {
+	panic("not implemented")
+}
+
+// DeleteIdx returns true if successful in deleting a value at a given index of the object.
+func (o *Object) DeleteIdx(idx uint32) bool {
+	panic("not implemented")
 }

--- a/object.go
+++ b/object.go
@@ -35,17 +35,12 @@ func (o *Object) SetIdx(idx uint32, val interface{}) error {
 }
 
 func set(o *Object, key string, idx uint32, val interface{}) error {
-	if o.ctx == nil {
-		return errors.New("v8go: unable to set property: Object has no Context")
-	}
-
 	var value *Value
 	switch v := val.(type) {
 	case string, int32, uint32, int64, uint64, float64, bool, *big.Int:
-		var err error
-		if value, err = NewValue(o.ctx.iso, v); err != nil {
-			return fmt.Errorf("v8go: unable to create new value: %v", err)
-		}
+		// ignoring error as code cannot reach the error state as we are already
+		// validating the new value types in this case statement
+		value, _ = NewValue(o.ctx.iso, v)
 	case Valuer:
 		value = v.value()
 	default:
@@ -65,9 +60,6 @@ func set(o *Object, key string, idx uint32, val interface{}) error {
 
 // Get tries to get a Value for a given Object property key.
 func (o *Object) Get(key string) (*Value, error) {
-	if o.ctx == nil {
-		return nil, errors.New("v8go: unable to set property: Object has no Context")
-	}
 	ckey := C.CString(key)
 	defer C.free(unsafe.Pointer(ckey))
 
@@ -84,20 +76,24 @@ func (o *Object) GetIdx(idx uint32) (*Value, error) {
 // Has calls the abstract operation HasProperty(O, P) described in ECMA-262, 7.3.10.
 // Returns true, if the object has the property, either own or on the prototype chain.
 func (o *Object) Has(key string) bool {
-	panic("not implemented")
+	ckey := C.CString(key)
+	defer C.free(unsafe.Pointer(ckey))
+	return C.ObjectHas(o.ptr, ckey) != 0
 }
 
 // HasIdx returns true if the object has a value at the given index.
 func (o *Object) HasIdx(idx uint32) bool {
-	panic("not implemented")
+	return C.ObjectHasIdx(o.ptr, C.uint32_t(idx)) != 0
 }
 
 // Delete returns true if successful in deleting a named property on the object.
 func (o *Object) Delete(key string) bool {
-	panic("not implemented")
+	ckey := C.CString(key)
+	defer C.free(unsafe.Pointer(ckey))
+	return C.ObjectDelete(o.ptr, ckey) != 0
 }
 
 // DeleteIdx returns true if successful in deleting a value at a given index of the object.
 func (o *Object) DeleteIdx(idx uint32) bool {
-	panic("not implemented")
+	return C.ObjectDeleteIdx(o.ptr, C.uint32_t(idx)) != 0
 }

--- a/object_template.go
+++ b/object_template.go
@@ -45,6 +45,7 @@ func NewObjectTemplate(iso *Isolate) (*ObjectTemplate, error) {
 	return &ObjectTemplate{tmpl}, nil
 }
 
+// NewInstance creates a new Object based on the template.
 func (o *ObjectTemplate) NewInstance(ctx *Context) (*Object, error) {
 	if ctx == nil {
 		return nil, errors.New("v8go: Context cannot be <nil>")

--- a/object_template.go
+++ b/object_template.go
@@ -45,6 +45,15 @@ func NewObjectTemplate(iso *Isolate) (*ObjectTemplate, error) {
 	return &ObjectTemplate{tmpl}, nil
 }
 
+func (o *ObjectTemplate) NewInstance(ctx *Context) (*Object, error) {
+	if ctx == nil {
+		return nil, errors.New("v8go: Context cannot be <nil>")
+	}
+
+	valPtr := C.ObjectTemplateNewInstance(o.ptr, ctx.ptr)
+	return &Object{&Value{valPtr, ctx}}, nil
+}
+
 func (o *ObjectTemplate) apply(opts *contextOptions) {
 	opts.gTmpl = o
 }

--- a/object_template_test.go
+++ b/object_template_test.go
@@ -113,3 +113,20 @@ func TestGlobalObjectTemplate(t *testing.T) {
 		})
 	}
 }
+
+func TestObjectTemplateNewInstace(t *testing.T) {
+	t.Parallel()
+	iso, _ := v8go.NewIsolate()
+	tmpl, _ := v8go.NewObjectTemplate(iso)
+	if _, err := tmpl.NewInstance(nil); err == nil {
+		t.Error("expected error but got <nil>")
+	}
+
+	tmpl.Set("foo", "bar")
+	ctx, _ := v8go.NewContext(iso)
+	obj, _ := tmpl.NewInstance(ctx)
+	if foo, _ := obj.Get("foo"); foo.String() != "bar" {
+		t.Errorf("unexpected value for object property: %v", foo)
+	}
+
+}

--- a/object_template_test.go
+++ b/object_template_test.go
@@ -118,7 +118,7 @@ func TestGlobalObjectTemplate(t *testing.T) {
 	}
 }
 
-func TestObjectTemplateNewInstace(t *testing.T) {
+func TestObjectTemplateNewInstance(t *testing.T) {
 	t.Parallel()
 	iso, _ := v8go.NewIsolate()
 	tmpl, _ := v8go.NewObjectTemplate(iso)

--- a/object_test.go
+++ b/object_test.go
@@ -2,15 +2,30 @@ package v8go_test
 
 import (
 	"fmt"
+	"testing"
 
 	"rogchap.com/v8go"
 )
 
+func TestObjectSet(t *testing.T) {
+
+}
+
+func TestObjectGet(t *testing.T) {
+
+}
+
+func TestObjectHas(t *testing.T) {
+
+}
+
+func TestObjectDelete(t *testing.T) {
+
+}
+
 func ExampleObject_global() {
 	iso, _ := v8go.NewIsolate()
-	obj, _ := v8go.NewObjectTemplate(iso)
-	obj.Set("version", "v1.0.0")
-	ctx, _ := v8go.NewContext(iso, obj)
+	ctx, _ := v8go.NewContext(iso)
 	global := ctx.Global()
 
 	console, _ := v8go.NewObjectTemplate(iso)

--- a/object_test.go
+++ b/object_test.go
@@ -8,18 +8,87 @@ import (
 )
 
 func TestObjectSet(t *testing.T) {
+	t.Parallel()
 
+	ctx, _ := v8go.NewContext()
+	val, _ := ctx.RunScript("const foo = {}; foo", "")
+	obj, _ := val.AsObject()
+	obj.Set("bar", "baz")
+	baz, _ := ctx.RunScript("foo.bar", "")
+	if baz.String() != "baz" {
+		t.Errorf("unexpected value: %q", baz)
+	}
+	if err := obj.Set("", nil); err == nil {
+		t.Error("expected error but got <nil>")
+	}
+	if err := obj.Set("a", 0); err == nil {
+		t.Error("expected error but got <nil>")
+	}
+	obj.SetIdx(10, "ten")
+	if ten, _ := ctx.RunScript("foo[10]", ""); ten.String() != "ten" {
+		t.Errorf("unexpected value: %q", ten)
+	}
 }
 
 func TestObjectGet(t *testing.T) {
+	t.Parallel()
 
+	ctx, _ := v8go.NewContext()
+	val, _ := ctx.RunScript("const foo = { bar: 'baz'}; foo", "")
+	obj, _ := val.AsObject()
+	if bar, _ := obj.Get("bar"); bar.String() != "baz" {
+		t.Errorf("unexpected value: %q", bar)
+	}
+	if baz, _ := obj.Get("baz"); !baz.IsUndefined() {
+		t.Errorf("unexpected value: %q", baz)
+	}
+	ctx.RunScript("foo[5] = 5", "")
+	if five, _ := obj.GetIdx(5); five.Integer() != 5 {
+		t.Errorf("unexpected value: %q", five)
+	}
+	if u, _ := obj.GetIdx(55); !u.IsUndefined() {
+		t.Errorf("unexpected value: %q", u)
+	}
 }
 
 func TestObjectHas(t *testing.T) {
+	t.Parallel()
 
+	ctx, _ := v8go.NewContext()
+	val, _ := ctx.RunScript("const foo = {a: 1, '2': 2}; foo", "")
+	obj, _ := val.AsObject()
+	if !obj.Has("a") {
+		t.Error("expected true, got false")
+	}
+	if obj.Has("c") {
+		t.Error("expected false, got true")
+	}
+	if !obj.HasIdx(2) {
+		t.Error("expected true, got false")
+	}
+	if obj.HasIdx(1) {
+		t.Error("expected false, got true")
+	}
 }
 
 func TestObjectDelete(t *testing.T) {
+	t.Parallel()
+
+	ctx, _ := v8go.NewContext()
+	val, _ := ctx.RunScript("const foo = { bar: 'baz', '2': 2}; foo", "")
+	obj, _ := val.AsObject()
+	if !obj.Has("bar") {
+		t.Error("expected property to exist")
+	}
+	if !obj.Delete("bar") {
+		t.Error("expected delete to return true, got false")
+	}
+	if obj.Has("bar") {
+		t.Error("expected property to be deleted")
+	}
+	if !obj.DeleteIdx(2) {
+		t.Error("expected delete to return true, got false")
+	}
 
 }
 

--- a/object_test.go
+++ b/object_test.go
@@ -1,0 +1,28 @@
+package v8go_test
+
+import (
+	"fmt"
+
+	"rogchap.com/v8go"
+)
+
+func ExampleObject_global() {
+	iso, _ := v8go.NewIsolate()
+	obj, _ := v8go.NewObjectTemplate(iso)
+	obj.Set("version", "v1.0.0")
+	ctx, _ := v8go.NewContext(iso, obj)
+	global := ctx.Global()
+
+	console, _ := v8go.NewObjectTemplate(iso)
+	logfn, _ := v8go.NewFunctionTemplate(iso, func(info *v8go.FunctionCallbackInfo) *v8go.Value {
+		fmt.Println(info.Args()[0])
+		return nil
+	})
+	console.Set("log", logfn)
+	consoleObj, _ := console.NewInstance(ctx)
+
+	global.Set("console", consoleObj)
+	ctx.RunScript("console.log('foo')", "")
+	// Output:
+	// foo
+}

--- a/object_test.go
+++ b/object_test.go
@@ -1,3 +1,7 @@
+// Copyright 2021 Roger Chapman and the v8go contributors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 package v8go_test
 
 import (

--- a/v8go.cc
+++ b/v8go.cc
@@ -887,13 +887,13 @@ void ObjectSet(ValuePtr ptr, const char* key, ValuePtr val_ptr) {
   LOCAL_OBJECT(ptr);
   Local<String> key_val = String::NewFromUtf8(iso, key, NewStringType::kNormal).ToLocalChecked();
   m_value* prop_val = static_cast<m_value*>(val_ptr);
-  Maybe<bool> set = obj->Set(local_ctx, key_val, prop_val->ptr.Get(iso));
+  obj->Set(local_ctx, key_val, prop_val->ptr.Get(iso)).Check();
 }
 
 void ObjectSetIdx(ValuePtr ptr, uint32_t idx, ValuePtr val_ptr) {
   LOCAL_OBJECT(ptr);
   m_value* prop_val = static_cast<m_value*>(val_ptr);
-  Maybe<bool> set = obj->Set(local_ctx, idx, prop_val->ptr.Get(iso));
+  obj->Set(local_ctx, idx, prop_val->ptr.Get(iso)).Check();
 }
 
 RtnValue ObjectGet(ValuePtr ptr, const char* key) {
@@ -931,6 +931,28 @@ RtnValue ObjectGetIdx(ValuePtr ptr, uint32_t idx) {
 
   rtn.value = static_cast<ValuePtr>(new_val);
   return rtn;
+}
+
+int ObjectHas(ValuePtr ptr, const char* key) {
+  LOCAL_OBJECT(ptr);
+  Local<String> key_val = String::NewFromUtf8(iso, key, NewStringType::kNormal).ToLocalChecked();
+  return obj->Has(local_ctx, key_val).ToChecked();
+}
+
+int ObjectHasIdx(ValuePtr ptr, uint32_t idx) {
+  LOCAL_OBJECT(ptr);
+  return obj->Has(local_ctx, idx).ToChecked();
+}
+
+int ObjectDelete(ValuePtr ptr, const char* key) {
+  LOCAL_OBJECT(ptr);
+  Local<String> key_val = String::NewFromUtf8(iso, key, NewStringType::kNormal).ToLocalChecked();
+  return obj->Delete(local_ctx, key_val).ToChecked();
+}
+
+int ObjectDeleteIdx(ValuePtr ptr, uint32_t idx) {
+  LOCAL_OBJECT(ptr);
+  return obj->Delete(local_ctx, idx).ToChecked();
 }
 
 /********** Version **********/

--- a/v8go.cc
+++ b/v8go.cc
@@ -702,6 +702,19 @@ int ValueIsModuleNamespaceObject(ValuePtr ptr) {
   return value->IsModuleNamespaceObject();
 }
 
+/********** Object **********/
+
+#define LOCAL_OBJECT(ptr)                           \
+    LOCAL_VALUE(ptr) \
+    Local<Object> obj = value.As<Object>() \
+
+void ObjectSet(ValuePtr ptr, const char* name, ValuePtr val_ptr) {
+  LOCAL_OBJECT(ptr);
+  Local<String> key = String::NewFromUtf8(iso, name, NewStringType::kNormal).ToLocalChecked();
+  m_value* val = static_cast<m_value*>(val_ptr);
+  obj->Set(ctx->ptr.Get(iso), key, val->ptr.Get(iso));
+}
+
 /********** Version **********/
 
 const char* Version() {

--- a/v8go.cc
+++ b/v8go.cc
@@ -906,12 +906,12 @@ RtnValue ObjectGet(ValuePtr ptr, const char* key) {
     rtn.error = ExceptionError(try_catch, iso, local_ctx);
     return rtn;
   }
-  m_value* val = new m_value;
-  val->iso = iso;
-  val->ctx.Reset(iso, local_ctx);
-  val->ptr.Reset(iso, Persistent<Value>(iso, result.ToLocalChecked()));
+  m_value* new_val = new m_value;
+  new_val->iso = iso;
+  new_val->ctx.Reset(iso, local_ctx);
+  new_val->ptr.Reset(iso, Persistent<Value>(iso, result.ToLocalChecked()));
 
-  rtn.value = static_cast<ValuePtr>(val);
+  rtn.value = static_cast<ValuePtr>(new_val);
   return rtn;
 }
 
@@ -924,12 +924,12 @@ RtnValue ObjectGetIdx(ValuePtr ptr, uint32_t idx) {
     rtn.error = ExceptionError(try_catch, iso, local_ctx);
     return rtn;
   }
-  m_value* val = new m_value;
-  val->iso = iso;
-  val->ctx.Reset(iso, local_ctx);
-  val->ptr.Reset(iso, Persistent<Value>(iso, result.ToLocalChecked()));
+  m_value* new_val = new m_value;
+  new_val->iso = iso;
+  new_val->ctx.Reset(iso, local_ctx);
+  new_val->ptr.Reset(iso, Persistent<Value>(iso, result.ToLocalChecked()));
 
-  rtn.value = static_cast<ValuePtr>(val);
+  rtn.value = static_cast<ValuePtr>(new_val);
   return rtn;
 }
 

--- a/v8go.cc
+++ b/v8go.cc
@@ -602,6 +602,7 @@ ValueBigInt ValueToBigInt(ValuePtr ptr) {
 ValuePtr ValueToObject(ValuePtr ptr) {
   LOCAL_VALUE(ptr);
   m_value* new_val = new m_value;
+  new_val->iso = iso;
   new_val->ctx.Reset(iso, local_ctx);
   new_val->ptr.Reset(iso, Persistent<Value>(iso, value->ToObject(local_ctx).ToLocalChecked()));
   return static_cast<ValuePtr>(new_val);

--- a/v8go.cc
+++ b/v8go.cc
@@ -282,6 +282,14 @@ ValueBigInt ValueToBigInt(ValuePtr ptr) {
   return rtn;
 }
 
+ValuePtr ValueToObject(ValuePtr ptr) {
+  LOCAL_VALUE(ptr);
+  m_value* val = new m_value;
+  val->ctx_ptr = ctx;
+  val->ptr.Reset(iso, Persistent<Value>(iso, value.ToObject(ctx->ptr.Get(iso).ToLocalChecked()));
+  return static_cast<ValuePtr>(val);
+}
+
 int ValueIsUndefined(ValuePtr ptr) {
   LOCAL_VALUE(ptr);
   return value->IsUndefined();

--- a/v8go.h
+++ b/v8go.h
@@ -156,6 +156,10 @@ extern void ObjectSet(ValuePtr ptr, const char* key, ValuePtr val_ptr);
 extern void ObjectSetIdx(ValuePtr ptr, uint32_t idx, ValuePtr val_ptr);
 extern RtnValue ObjectGet(ValuePtr ptr, const char* key);
 extern RtnValue ObjectGetIdx(ValuePtr ptr, uint32_t idx);
+int ObjectHas(ValuePtr ptr, const char* key);
+int ObjectHasIdx(ValuePtr ptr, uint32_t idx);
+int ObjectDelete(ValuePtr ptr, const char* key);
+int ObjectDeleteIdx(ValuePtr ptr, uint32_t idx);
 
 const char* Version();
 

--- a/v8go.h
+++ b/v8go.h
@@ -138,6 +138,8 @@ int ValueIsProxy(ValuePtr ptr);
 int ValueIsWasmModuleObject(ValuePtr ptr);
 int ValueIsModuleNamespaceObject(ValuePtr ptr);
 
+extern void ObjectSet(ValuePtr ptr, const char* name, ValuePtr val_ptr) {
+
 const char* Version();
 
 #ifdef __cplusplus

--- a/v8go.h
+++ b/v8go.h
@@ -64,6 +64,7 @@ double ValueToNumber(ValuePtr ptr);
 const char* ValueToDetailString(ValuePtr ptr);
 uint32_t ValueToUint32(ValuePtr ptr);
 extern ValueBigInt ValueToBigInt(ValuePtr ptr);
+extern ValuePtr ValueToObject(ValuePtr ptr);
 int ValueIsUndefined(ValuePtr ptr);
 int ValueIsNull(ValuePtr ptr);
 int ValueIsNullOrUndefined(ValuePtr ptr);

--- a/v8go.h
+++ b/v8go.h
@@ -58,6 +58,7 @@ extern RtnValue RunScript(ContextPtr ctx_ptr,
                           const char* origin);
 extern RtnValue JSONParse(ContextPtr ctx_ptr, const char* str);
 const char* JSONStringify(ContextPtr ctx_ptr, ValuePtr val_ptr);
+extern ValuePtr ContextGlobal(ContextPtr ctx_ptr);
 
 extern void TemplateFree(TemplatePtr ptr);
 extern void TemplateSetValue(TemplatePtr ptr,
@@ -70,6 +71,8 @@ extern void TemplateSetTemplate(TemplatePtr ptr,
                                 int attributes);
 
 extern TemplatePtr NewObjectTemplate(IsolatePtr iso_ptr);
+extern ValuePtr ObjectTemplateNewInstance(TemplatePtr ptr, ContextPtr ctx_ptr);
+
 extern TemplatePtr NewFunctionTemplate(IsolatePtr iso_ptr, int callback_ref);
 
 extern ValuePtr NewValueInteger(IsolatePtr iso_ptr, int32_t v);
@@ -149,7 +152,8 @@ int ValueIsProxy(ValuePtr ptr);
 int ValueIsWasmModuleObject(ValuePtr ptr);
 int ValueIsModuleNamespaceObject(ValuePtr ptr);
 
-extern void ObjectSet(ValuePtr ptr, const char* name, ValuePtr val_ptr) {
+extern void ObjectSet(ValuePtr ptr, const char* name, ValuePtr val_ptr);
+extern void ObjectSetIdx(ValuePtr ptr, uint32_t idx, ValuePtr val_ptr);
 
 const char* Version();
 

--- a/v8go.h
+++ b/v8go.h
@@ -152,8 +152,10 @@ int ValueIsProxy(ValuePtr ptr);
 int ValueIsWasmModuleObject(ValuePtr ptr);
 int ValueIsModuleNamespaceObject(ValuePtr ptr);
 
-extern void ObjectSet(ValuePtr ptr, const char* name, ValuePtr val_ptr);
+extern void ObjectSet(ValuePtr ptr, const char* key, ValuePtr val_ptr);
 extern void ObjectSetIdx(ValuePtr ptr, uint32_t idx, ValuePtr val_ptr);
+extern RtnValue ObjectGet(ValuePtr ptr, const char* key);
+extern RtnValue ObjectGetIdx(ValuePtr ptr, uint32_t idx);
 
 const char* Version();
 

--- a/value.go
+++ b/value.go
@@ -18,7 +18,9 @@ type Value struct {
 	ctx *Context
 }
 
-type valuer interface {
+// Valuer is an interface that reperesents anything that extends from a Value
+// eg. Object, Array, Date etc
+type Valuer interface {
 	value() *Value
 }
 
@@ -201,7 +203,7 @@ func (v *Value) Number() float64 {
 // To just cast this value as an Object use AsObject() instead.
 func (v *Value) Object() *Object {
 	ptr := C.ValueToObject(v.ptr)
-	val := &Value{ptr}
+	val := &Value{ptr, v.ctx}
 	runtime.SetFinalizer(val, (*Value).finalizer)
 	return &Object{val}
 }

--- a/value.go
+++ b/value.go
@@ -18,6 +18,14 @@ type Value struct {
 	ctx *Context
 }
 
+type valuer interface {
+	value() *Value
+}
+
+func (v *Value) value() *Value {
+	return v
+}
+
 // NewValue will create a primitive value. Supported values types to create are:
 //   string -> V8::String
 //   int32 -> V8::Integer
@@ -190,8 +198,8 @@ func (v *Value) Number() float64 {
 // Object perform the equivalent of Object(value) in JS.
 // To just cast this value as an Object use AsObject() instead.
 func (v *Value) Object() *Object {
-	valPtr := C.ValueToObject(v.ptr)
-	val := &Value{valPtr}
+	ptr := C.ValueToObject(v.ptr)
+	val := &Value{ptr}
 	runtime.SetFinalizer(val, (*Value).finalizer)
 	return &Object{val}
 }

--- a/value_test.go
+++ b/value_test.go
@@ -351,25 +351,16 @@ func TestValueBigInt(t *testing.T) {
 
 func TestValueObject(t *testing.T) {
 	t.Parallel()
-	iso, _ := v8go.NewIsolate()
 
-	tests := [...]struct {
-		source   string
-		expected func(obj *v8go.Object) bool
-	}{}
-
-	for _, tt := range tests {
-		tt := tt
-		t.Run(tt.source, func(t *testing.T) {
-			t.Parallel()
-			ctx, _ := v8go.NewContext(iso)
-			val, _ := ctx.RunScript(tt.source, "test.js")
-			obj := val.Object()
-			if !tt.expected(obj) {
-				t.Errorf("unexpected value: %v", obj)
-			}
-		})
+	ctx, _ := v8go.NewContext()
+	val, _ := ctx.RunScript("1", "")
+	if _, err := val.AsObject(); err == nil {
+		t.Error("Expected error but got <nil>")
 	}
+	if obj := val.Object(); obj.String() != "1" {
+		t.Errorf("unexpected object value: %v", obj)
+	}
+
 }
 
 func TestValueIsXXX(t *testing.T) {

--- a/value_test.go
+++ b/value_test.go
@@ -355,7 +355,7 @@ func TestValueObject(t *testing.T) {
 
 	tests := [...]struct {
 		source   string
-		expected func(obj *Object) bool
+		expected func(obj *v8go.Object) bool
 	}{}
 
 	for _, tt := range tests {

--- a/value_test.go
+++ b/value_test.go
@@ -348,7 +348,29 @@ func TestValueBigInt(t *testing.T) {
 			}
 		})
 	}
+}
 
+func TestValueObject(t *testing.T) {
+	t.Parallel()
+	iso, _ := v8go.NewIsolate()
+
+	tests := [...]struct {
+		source   string
+		expected func(obj *Object) bool
+	}{}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.source, func(t *testing.T) {
+			t.Parallel()
+			ctx, _ := v8go.NewContext(iso)
+			val, _ := ctx.RunScript(tt.source, "test.js")
+			obj := val.Object()
+			if !tt.expected(obj) {
+				t.Errorf("unexpected value: %v", obj)
+			}
+		})
+	}
 }
 
 func TestValueIsXXX(t *testing.T) {


### PR DESCRIPTION
Basic casting of a Value to an Object (`val.AsObject()`) as well as converting Value to an Object (`val.Object()`)

Only covers a small subset of the Object API as described here: https://v8.github.io/api/head/classv8_1_1Object.html

Also includes converting an `ObjectTemplate` to an `Object` with a given Context, and retrieving the Global Object from a Context.

This allows for things like this at runtime: 
```go
iso, _ := v8go.NewIsolate()
obj, _ := v8go.NewObjectTemplate(iso)
ctx, _ := v8go.NewContext(iso, obj)
global := ctx.Global()
console, _ := v8go.NewObjectTemplate(iso)
logfn, _ := v8go.NewFunctionTemplate(iso, func(info *v8go.FunctionCallbackInfo) *v8go.Value {
	fmt.Println(info.Args()[0])
	return nil
})
console.Set("log", logfn)
consoleObj, _ := console.NewInstance(ctx)
global.Set("console", consoleObj)
ctx.RunScript("console.log('foo')", "")
// Output:
// foo
```