### PR TITLE
Release value memory on context close

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [v0.5.1] - 2021-02-19
+
+### Fixed
+- Memory being held by Values after the associated Context is closed
+
 ## [v0.5.0] - 2021-02-08
 
 ### Added

--- a/context_test.go
+++ b/context_test.go
@@ -97,14 +97,14 @@ func TestMemoryLeak(t *testing.T) {
 
 	iso, _ := v8go.NewIsolate()
 
-	for i := 0; i < 2000; i++ {
+	for i := 0; i < 6000; i++ {
 		ctx, _ := v8go.NewContext(iso)
 		obj := ctx.Global()
 		_ = obj.String()
 		_, _ = ctx.RunScript("2", "")
 		ctx.Close()
 	}
-	if n := iso.GetHeapStatistics().NumberOfNativeContexts; n >= 2000 {
+	if n := iso.GetHeapStatistics().NumberOfNativeContexts; n >= 6000 {
 		t.Errorf("Context not being GC'd, got %d native contexts", n)
 	}
 }

--- a/context_test.go
+++ b/context_test.go
@@ -92,6 +92,23 @@ func TestContextRegistry(t *testing.T) {
 	}
 }
 
+func TestMemoryLeak(t *testing.T) {
+	t.Parallel()
+
+	iso, _ := v8go.NewIsolate()
+
+	for i := 0; i < 2000; i++ {
+		ctx, _ := v8go.NewContext(iso)
+		obj := ctx.Global()
+		_ = obj.String()
+		_, _ = ctx.RunScript("2", "")
+		ctx.Close()
+	}
+	if n := iso.GetHeapStatistics().NumberOfNativeContexts; n >= 2000 {
+		t.Errorf("Context not being GC'd, got %d native contexts", n)
+	}
+}
+
 func BenchmarkContext(b *testing.B) {
 	b.ReportAllocs()
 	vm, _ := v8go.NewIsolate()

--- a/function_template.go
+++ b/function_template.go
@@ -70,7 +70,6 @@ func goFunctionCallback(ctxref int, cbref int, args *C.ValuePtr, argsCount int) 
 	argv := (*[1 << 30]C.ValuePtr)(unsafe.Pointer(args))[:argsCount:argsCount]
 	for i, v := range argv {
 		val := &Value{ptr: v}
-		runtime.SetFinalizer(val, (*Value).finalizer)
 		info.args[i] = val
 	}
 

--- a/v8go.cc
+++ b/v8go.cc
@@ -114,7 +114,7 @@ ValuePtr tracked_value(m_ctx* ctx, m_value* val) {
   ValuePtr val_ptr = static_cast<ValuePtr>(val);
   ctx->vals.push_back(val_ptr);
 
-  return static_cast<ValuePtr>(val);
+  return val_ptr;
 }
 
 extern "C" {

--- a/v8go.h
+++ b/v8go.h
@@ -5,6 +5,7 @@
 #ifndef V8GO_H
 #define V8GO_H
 #ifdef __cplusplus
+
 extern "C" {
 #endif
 

--- a/value.go
+++ b/value.go
@@ -208,7 +208,6 @@ func (v *Value) Number() float64 {
 func (v *Value) Object() *Object {
 	ptr := C.ValueToObject(v.ptr)
 	val := &Value{ptr, v.ctx}
-	runtime.SetFinalizer(val, (*Value).finalizer)
 	return &Object{val}
 }
 


### PR DESCRIPTION
See https://gophers.slack.com/archives/C01FW4CR5D2/p1613070695024600 for full details.

TLDR; When returning a value to Go from a V8 Context the Persistent Value storage was not being Reset correctly, and also stopped the V8 Context from being GC'd. Added memory issues where also caused by Go's GC not firing fast enough as it does not understand the memory allocated to the objects held by pointers in the C world.

This fix, tracks Values returned from the context, and when the Context is closed (either manually or by the Go GC) it will also reset all those values correctly.