### PR TITLE
Fix FOSSA scan on Windows

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,10 +39,17 @@ jobs:
         env_vars: OS,GO
     - name: Add GOPATH to GITHUB_ENV
       run: echo "GOPATH=$(go env GOPATH)" >>"$GITHUB_ENV"
-    - name: Scan and upload FOSSA data
-      if: github.ref == 'refs/heads/master'
+    - name: Scan and upload FOSSA data (Linux/Mac)
+      if: github.ref == 'refs/heads/master' && matrix.platform != 'windows-latest'
       run: |
         curl -H 'Cache-Control: no-cache' https://raw.githubusercontent.com/fossas/fossa-cli/master/install.sh | sudo bash
         fossa analyze
+      env:
+        FOSSA_API_KEY: ${{ secrets.FOSSA_API_KEY }}
+    - name: Scan and upload FOSSA data (Windows)
+      if: github.ref == 'refs/heads/master' && matrix.platform == 'windows-latest'
+      run: |
+        Set-ExecutionPolicy Bypass -Scope Process -Force; iex  ((New-Object System.Net.WebClient).DownloadString('https://raw.githubusercontent.com/fossas/fossa-cli/master/install.ps1'))
+        C:\ProgramData\fossa-cli\fossa.exe analyze
       env:
         FOSSA_API_KEY: ${{ secrets.FOSSA_API_KEY }}


### PR DESCRIPTION
@rogchap Missed that the FOSSA step would break the Windows build in #102, sorry.

If the scan doesn't have to run on Windows and can be skipped, feel free to close this PR (and just copy the skip condition from line 43).
Otherwise the separate step using Powershell is required, because the FOSSA install script doesn't work in Git bash on Windows.
