### PR TITLE
Add Function.NewInstance to expose the corresponding V8 function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Support for calling constructors functions with NewInstance on Function
+
 ## [v0.6.0] - 2021-05-11
 
 ### Added

--- a/context.go
+++ b/context.go
@@ -179,6 +179,13 @@ func getValue(ctx *Context, rtn C.RtnValue) *Value {
 	return &Value{rtn.value, ctx}
 }
 
+func getObject(ctx *Context, rtn C.RtnValue) *Object {
+	if rtn.value == nil {
+		return nil
+	}
+	return &Object{&Value{rtn.value, ctx}}
+}
+
 func getError(rtn C.RtnValue) error {
 	if rtn.error.msg == nil {
 		return nil

--- a/function.go
+++ b/function.go
@@ -30,3 +30,19 @@ func (fn *Function) Call(args ...Valuer) (*Value, error) {
 	fn.ctx.deregister()
 	return getValue(fn.ctx, rtn), getError(rtn)
 }
+
+// Invoke a constructor function to create an object instance.
+func (fn *Function) NewInstance(args ...Valuer) (*Object, error) {
+	var argptr *C.ValuePtr
+	if len(args) > 0 {
+		var cArgs = make([]C.ValuePtr, len(args))
+		for i, arg := range args {
+			cArgs[i] = arg.value().ptr
+		}
+		argptr = (*C.ValuePtr)(unsafe.Pointer(&cArgs[0]))
+	}
+	fn.ctx.register()
+	rtn := C.FunctionNewInstance(fn.ptr, C.int(len(args)), argptr)
+	fn.ctx.deregister()
+	return getObject(fn.ctx, rtn), getError(rtn)
+}

--- a/function_test.go
+++ b/function_test.go
@@ -86,6 +86,35 @@ func TestFunctionCallError(t *testing.T) {
 	}
 }
 
+func TestFunctionNewInstance(t *testing.T) {
+	t.Parallel()
+
+	ctx, err := v8go.NewContext()
+	failIf(t, err)
+	iso, err := ctx.Isolate()
+	failIf(t, err)
+
+	value, err := ctx.Global().Get("Error")
+	failIf(t, err)
+	fn, err := value.AsFunction()
+	failIf(t, err)
+	messageObj, err := v8go.NewValue(iso, "test message")
+	failIf(t, err)
+	errObj, err := fn.NewInstance(messageObj)
+	failIf(t, err)
+
+	message, err := errObj.Get("message")
+	failIf(t, err)
+	if !message.IsString() {
+		t.Error("missing error message")
+	}
+	want := "test message"
+	got := message.String()
+	if got != want {
+		t.Errorf("want %+v, got: %+v", want, got)
+	}
+}
+
 func failIf(t *testing.T, err error) {
 	t.Helper()
 	if err != nil {

--- a/function_test.go
+++ b/function_test.go
@@ -115,6 +115,28 @@ func TestFunctionNewInstance(t *testing.T) {
 	}
 }
 
+func TestFunctionNewInstanceError(t *testing.T) {
+	t.Parallel()
+
+	ctx, err := v8go.NewContext()
+	failIf(t, err)
+	_, err = ctx.RunScript("function throws() { throw 'error'; }", "script.js")
+	failIf(t, err)
+	throwsValue, err := ctx.Global().Get("throws")
+	failIf(t, err)
+	fn, _ := throwsValue.AsFunction()
+
+	_, err = fn.NewInstance()
+	if err == nil {
+		t.Errorf("expected an error, got none")
+	}
+	got := *(err.(*v8go.JSError))
+	want := v8go.JSError{Message: "error", Location: "script.js:1:21"}
+	if got != want {
+		t.Errorf("want %+v, got: %+v", want, got)
+	}
+}
+
 func failIf(t *testing.T, err error) {
 	t.Helper()
 	if err != nil {

--- a/v8go.h
+++ b/v8go.h
@@ -179,6 +179,7 @@ ValuePtr PromiseCatch(ValuePtr ptr, int callback_ref);
 extern ValuePtr PromiseResult(ValuePtr ptr);
 
 extern RtnValue FunctionCall(ValuePtr ptr, int argc, ValuePtr argv[]);
+RtnValue FunctionNewInstance(ValuePtr ptr, int argc, ValuePtr args[]);
 
 extern ValuePtr ExceptionError(IsolatePtr iso_ptr, const char* message);
 extern ValuePtr ExceptionRangeError(IsolatePtr iso_ptr, const char* message);


### PR DESCRIPTION
## Problem

I was trying to do something like `new Error(message)` from Go code, but didn't see a way of using the javascript `new` operator.

## Solution

It looks like v8::Function::NewInstance is the function we need for doing this, so I added a corresponding function to the v8go API.