### PR TITLE
Build v8 with i18n support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Support for calling constructors functions with NewInstance on Function
+- Build v8 with i18n support
 
 ## [v0.6.0] - 2021-05-11
 

--- a/deps/build.py
+++ b/deps/build.py
@@ -51,7 +51,6 @@ v8_use_external_startup_data=false
 treat_warnings_as_errors=false
 v8_embedder_string="-v8go"
 v8_enable_gdbjit=false
-v8_enable_i18n_support=false
 v8_enable_test_features=false
 v8_untrusted_code_mitigations=false
 exclude_unwind_tables=true


### PR DESCRIPTION
## Problem

I was getting an `ReferenceError: Intl is not defined` error from trying to use the Intl JS namespace which is a builtin feature of v8 (https://v8.dev/blog/intl).  I found this wasn't working because v8go was building with `v8_enable_i18n_support=false`.

## Solution

Removing `v8_enable_i18n_support=false` from the build configuration and rebuilding solved the problem for me.

As instructed in the README.md, I didn't add any built binaries to the commit I pushed.  I don't have access to run the "V8 Build" Github Action, so that still needs to be done to update the pre-built binaries in order to actually fix this issue.