### PR TITLE
uint8 array support

### DIFF
--- a/array_test.go
+++ b/array_test.go
@@ -31,7 +31,7 @@ func (nto *nativeObject) GetReverseUint8ArrayFunctionCallback() FunctionCallback
 		if !args[0].IsUint8Array() {
 			return iso.ThrowException("Function ReverseUint8Array expects Uint8Array parameter")
 		}
-		array := args[0].Uint8Array() //TODO who frees this
+		array := args[0].Uint8Array()
 		length := len(array)
 		reversed := make([]uint8, length)
 		for i := 0; i < length; i++ {
@@ -131,4 +131,22 @@ func TestNativeUint8ArrayException(t *testing.T) {
 	} else {
 		t.Errorf("Should have received an error from the script")
 	}
+}
+
+func TestNativeUint8ArrayManyCalls(t *testing.T) {
+	t.Parallel()
+	iso, _ := NewIsolate()
+	ctx, _ := NewContext(iso)
+	if err := injectNativeObject(ctx); err != nil {
+		t.Error(err)
+	}
+	stats := iso.GetHeapStatistics()
+	fmt.Printf("MEMSTATS BEFORE: %+v\n", stats)
+
+	if _, err := ctx.RunScript("for(i = 0; i < 100000; i++) native.reverseUint8Array(new Uint8Array([0,1,2,3,4,5,6,7,8,9]));", ""); err != nil {
+		t.Error(err)
+	}
+
+	stats = iso.GetHeapStatistics()
+	fmt.Printf("MEMSTATS AFTER: %+v\n", stats)
 }

--- a/array_test.go
+++ b/array_test.go
@@ -1,0 +1,119 @@
+package v8go
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"testing"
+)
+
+type NativeObject interface {
+	GetReverseUint8ArrayFunctionCallback() FunctionCallback
+}
+
+type nativeObject struct {
+}
+
+func NewNativeObject() NativeObject {
+	return &nativeObject{}
+}
+
+func (nto *nativeObject) GetReverseUint8ArrayFunctionCallback() FunctionCallback {
+	return func(info *FunctionCallbackInfo) *Value {
+		args := info.Args()
+		if len(args) != 1 {
+			os.Stderr.WriteString("Function ReverseUint8Array expects 1 parameter\n") //TODO
+			return nil
+		}
+		iso, err := info.Context().Isolate()
+		if err != nil {
+			os.Stderr.WriteString(fmt.Sprintf("Could not get isolate from context: %v\n", err)) //TODO
+			return nil
+		}
+		if !args[0].IsUint8Array() {
+			os.Stderr.WriteString("Function ReverseUint8Array expects Uint8Array parameter\n") //TODO
+			return nil
+		}
+		inarray := args[0].Uint8Array() //TODO who frees this
+		length := len(inarray)
+		reversed := make([]uint8, length)
+		for i := 0; i < length; i++ {
+			reversed[i] = inarray[length-i-1]
+		}
+		val, err := NewValue(iso, reversed)
+		if err != nil {
+			os.Stderr.WriteString(fmt.Sprintf("Could not get value for array: %v\n", err))
+			return nil
+		}
+		return val
+	}
+}
+
+func injectNativeObject(ctx *Context) error {
+	if ctx == nil {
+		return errors.New("injectNativeObject: ctx is required")
+	}
+
+	iso, err := ctx.Isolate()
+	if err != nil {
+		return fmt.Errorf("injectNativeObject: %w", err)
+	}
+
+	c := NewNativeObject()
+
+	con, err := NewObjectTemplate(iso)
+	if err != nil {
+		return fmt.Errorf("injectNativeObject: %w", err)
+	}
+
+	reverseFn, err := NewFunctionTemplate(iso, c.GetReverseUint8ArrayFunctionCallback())
+	if err != nil {
+		return fmt.Errorf("injectNativeObject: %w", err)
+	}
+
+	if err := con.Set("reverseUint8Array", reverseFn, ReadOnly); err != nil {
+		return fmt.Errorf("injectNativeObject: %w", err)
+	}
+
+	nativeObj, err := con.NewInstance(ctx)
+	if err != nil {
+		return fmt.Errorf("injectNativeObject: %w", err)
+	}
+
+	global := ctx.Global()
+
+	if err := global.Set("native", nativeObj); err != nil {
+		return fmt.Errorf("injectNativeObject: %w", err)
+	}
+
+	return nil
+}
+
+func TestNativeUint8Array(t *testing.T) {
+	t.Parallel()
+
+	iso, _ := NewIsolate()
+	ctx, _ := NewContext(iso)
+
+	if err := injectNativeObject(ctx); err != nil {
+		t.Error(err)
+	}
+
+	if val, err := ctx.RunScript("native.reverseUint8Array(new Uint8Array([0,1,2,3,4,5,6,7,8,9]))", ""); err != nil {
+		t.Error(err)
+	} else {
+		if !val.IsUint8Array() {
+			t.Errorf("Expected uint8 array return value")
+		}
+		fmt.Printf("Reversed array: %v\n", val.Uint8Array())
+		arr := val.Uint8Array()
+		if len(arr) != 10 {
+			t.Errorf("Got wrong array length %d, expected 10", len(arr))
+		}
+		for i := 0; i < 10; i++ {
+			if arr[i] != uint8(10-i-1) {
+				t.Errorf("Incorrect byte at index %d (whole array: %v)", i, arr)
+			}
+		}
+	}
+}

--- a/array_test.go
+++ b/array_test.go
@@ -132,21 +132,3 @@ func TestNativeUint8ArrayException(t *testing.T) {
 		t.Errorf("Should have received an error from the script")
 	}
 }
-
-func TestNativeUint8ArrayManyCalls(t *testing.T) {
-	t.Parallel()
-	iso, _ := NewIsolate()
-	ctx, _ := NewContext(iso)
-	if err := injectNativeObject(ctx); err != nil {
-		t.Error(err)
-	}
-	stats := iso.GetHeapStatistics()
-	fmt.Printf("MEMSTATS BEFORE: %+v\n", stats)
-
-	if _, err := ctx.RunScript("for(i = 0; i < 100000; i++) native.reverseUint8Array(new Uint8Array([0,1,2,3,4,5,6,7,8,9]));", ""); err != nil {
-		t.Error(err)
-	}
-
-	stats = iso.GetHeapStatistics()
-	fmt.Printf("MEMSTATS AFTER: %+v\n", stats)
-}

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module rogchap.com/v8go
 
 go 1.12
+
+require github.com/golang/protobuf v1.5.2

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,9 @@
+github.com/golang/protobuf v1.5.0/go.mod h1:FsONVRAS9T7sI+LIUmWTfcYkHO4aIWwzhcaSAoJOfIk=
+github.com/golang/protobuf v1.5.2 h1:ROPKBNFfQgOUMifHyP+KYbvpjbdoFNs+aK7DXlji0Tw=
+github.com/golang/protobuf v1.5.2/go.mod h1:XVQd3VNwM+JqD3oG2Ue2ip4fOMUkwXdXDdiuN0vRsmY=
+github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+github.com/protocolbuffers/protobuf v3.17.2+incompatible h1:ZM85np8wovAzyCCjAF9oZydM0VZh13Khe1633aDtJhA=
+golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
+google.golang.org/protobuf v1.26.0-rc.1/go.mod h1:jlhhOSvTdKEhbULTjvd4ARK9grFBp09yW+WbY/TyQbw=
+google.golang.org/protobuf v1.26.0 h1:bxAC2xTBsZGibn2RTntX0oH50xLsqy1OxA9tTL3p/lk=
+google.golang.org/protobuf v1.26.0/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=

--- a/isolate.go
+++ b/isolate.go
@@ -4,11 +4,13 @@
 
 package v8go
 
+// #include <stdlib.h>
 // #include "v8go.h"
 import "C"
 
 import (
 	"sync"
+	"unsafe"
 )
 
 var v8once sync.Once
@@ -114,4 +116,11 @@ func (i *Isolate) getCallback(ref int) FunctionCallback {
 	i.cbMutex.RLock()
 	defer i.cbMutex.RUnlock()
 	return i.cbs[ref]
+}
+
+func (i *Isolate) ThrowException(msg string) *Value {
+	cmsg := C.CString(msg)
+	defer C.free(unsafe.Pointer(cmsg))
+	C.ThrowException(i.ptr, cmsg)
+	return nil
 }

--- a/isolate.go
+++ b/isolate.go
@@ -118,7 +118,7 @@ func (i *Isolate) getCallback(ref int) FunctionCallback {
 	return i.cbs[ref]
 }
 
-func (i *Isolate) ThrowException(msg string) *Value {
+func (i *Isolate) ThrowException(msg string) *Value { // TwinTag added
 	cmsg := C.CString(msg)
 	defer C.free(unsafe.Pointer(cmsg))
 	C.ThrowException(i.ptr, cmsg)

--- a/v8go.cc
+++ b/v8go.cc
@@ -1230,6 +1230,12 @@ RtnValue FunctionCall(ValuePtr ptr, int argc, ValuePtr args[]) {
 
 /******** Exceptions *********/
 
+void ThrowException(IsolatePtr iso_ptr, const char* message) { // TwinTag added
+  ISOLATE_SCOPE(iso_ptr);
+  Local<String> msg = String::NewFromUtf8(iso, message).ToLocalChecked();
+  iso->ThrowException(msg);
+}
+
 ValuePtr ExceptionError(IsolatePtr iso_ptr, const char* message) {
   ISOLATE_SCOPE(iso_ptr);
   Local<String> msg = String::NewFromUtf8(iso, message).ToLocalChecked();

--- a/v8go.cc
+++ b/v8go.cc
@@ -560,6 +560,33 @@ ValuePtr NewValueString(IsolatePtr iso_ptr, const char* v) {
   return tracked_value(ctx, val);
 }
 
+ValuePtr NewValueUint8Array(IsolatePtr iso_ptr, const uint8_t *v, int len) {
+fprintf(stderr, "NewValueUint8Array(len %d)\n", len);
+
+  ISOLATE_SCOPE_INTERNAL_CONTEXT(iso_ptr);
+  Local<Context> c = ctx->ptr.Get(iso);
+  c->Enter(); // ArrayBuffer::New() needs a Context
+
+fprintf(stderr, "Creating array buffer\n"); //TODO REMOVEME
+
+    Local<ArrayBuffer> arbuf = ArrayBuffer::New(iso,
+        (void*)v, len,
+        ArrayBufferCreationMode::kInternalized); //TODO check if memory gets freed
+
+fprintf(stderr, "Created array buffer!!!\n"); //TODO REMOVEME
+
+  m_value* val = new m_value;
+  val->iso = iso;
+  val->ctx = ctx;
+  val->ptr = Persistent<Value, CopyablePersistentTraits<Value>>(
+      iso, Uint8Array::New(arbuf, 0, len));
+
+  c->Exit();
+
+  return tracked_value(ctx, val);
+}
+
+
 ValuePtr NewValueBoolean(IsolatePtr iso_ptr, int v) {
   ISOLATE_SCOPE_INTERNAL_CONTEXT(iso_ptr);
   m_value* val = new m_value;

--- a/v8go.cc
+++ b/v8go.cc
@@ -571,9 +571,13 @@ ValuePtr NewValueUint8Array(IsolatePtr iso_ptr, const uint8_t *v, int len) { // 
   // They are not needed when this code gets called through an executing script.
   c->Enter();
 
-  Local<ArrayBuffer> arbuf = ArrayBuffer::New(iso,
-      static_cast<void*>(const_cast<uint8_t*>(v)), len,
-      ArrayBufferCreationMode::kInternalized); // ArrayBuffer now owns the memory
+  std::unique_ptr<BackingStore> bs = ArrayBuffer::NewBackingStore(
+    static_cast<void*>(const_cast<uint8_t*>(v)), len,
+    [](void* data, size_t length, void *deleter_data) {
+      free(data);
+      }, nullptr);
+
+  Local<ArrayBuffer> arbuf = ArrayBuffer::New(iso, std::move(bs));
 
   m_value* val = new m_value;
   val->iso = iso;

--- a/v8go.h
+++ b/v8go.h
@@ -85,6 +85,7 @@ extern ValuePtr FunctionTemplateGetFunction(TemplatePtr ptr, ContextPtr ctx_ptr)
 extern ValuePtr NewValueInteger(IsolatePtr iso_ptr, int32_t v);
 extern ValuePtr NewValueIntegerFromUnsigned(IsolatePtr iso_ptr, uint32_t v);
 extern ValuePtr NewValueString(IsolatePtr iso_ptr, const char* v);
+extern ValuePtr NewValueUint8Array(IsolatePtr iso_ptr, const uint8_t* v, int len);
 extern ValuePtr NewValueBoolean(IsolatePtr iso_ptr, int v);
 extern ValuePtr NewValueNumber(IsolatePtr iso_ptr, double v);
 extern ValuePtr NewValueBigInt(IsolatePtr iso_ptr, int64_t v);

--- a/v8go.h
+++ b/v8go.h
@@ -104,6 +104,8 @@ double ValueToNumber(ValuePtr ptr);
 const char* ValueToDetailString(ValuePtr ptr);
 uint32_t ValueToUint32(ValuePtr ptr);
 extern ValueBigInt ValueToBigInt(ValuePtr ptr);
+extern uint8_t* ValueToUint8Array(ValuePtr ptr); // TwinTag added
+extern uint64_t ValueToArrayLength(ValuePtr ptr); // TwinTag added
 extern ValuePtr ValueToObject(ValuePtr ptr);
 int ValueIsUndefined(ValuePtr ptr);
 int ValueIsNull(ValuePtr ptr);

--- a/v8go.h
+++ b/v8go.h
@@ -85,7 +85,7 @@ extern ValuePtr FunctionTemplateGetFunction(TemplatePtr ptr, ContextPtr ctx_ptr)
 extern ValuePtr NewValueInteger(IsolatePtr iso_ptr, int32_t v);
 extern ValuePtr NewValueIntegerFromUnsigned(IsolatePtr iso_ptr, uint32_t v);
 extern ValuePtr NewValueString(IsolatePtr iso_ptr, const char* v);
-extern ValuePtr NewValueUint8Array(IsolatePtr iso_ptr, const uint8_t* v, int len);
+extern ValuePtr NewValueUint8Array(IsolatePtr iso_ptr, const uint8_t* v, int len); // TwinTag added
 extern ValuePtr NewValueBoolean(IsolatePtr iso_ptr, int v);
 extern ValuePtr NewValueNumber(IsolatePtr iso_ptr, double v);
 extern ValuePtr NewValueBigInt(IsolatePtr iso_ptr, int64_t v);

--- a/v8go.h
+++ b/v8go.h
@@ -183,6 +183,8 @@ extern ValuePtr PromiseResult(ValuePtr ptr);
 
 extern RtnValue FunctionCall(ValuePtr ptr, int argc, ValuePtr argv[]);
 
+extern void ThrowException(IsolatePtr iso_ptr, const char* message); // TwinTag added
+
 extern ValuePtr ExceptionError(IsolatePtr iso_ptr, const char* message);
 extern ValuePtr ExceptionRangeError(IsolatePtr iso_ptr, const char* message);
 extern ValuePtr ExceptionReferenceError(IsolatePtr iso_ptr,

--- a/value.go
+++ b/value.go
@@ -82,7 +82,7 @@ func NewValue(iso *Isolate, val interface{}) (*Value, error) {
 		rtnVal = &Value{
 			ptr: C.NewValueNumber(iso.ptr, C.double(v)),
 		}
-	case []uint8:
+	case []uint8: // TwinTag added
 		rtnVal = &Value{
 			//NOTE: C.CBytes() allocates memory, must be freed
 			ptr: C.NewValueUint8Array(iso.ptr, (*C.uchar)(C.CBytes(v)), C.int(len(v))),
@@ -174,6 +174,13 @@ func (v *Value) BigInt() *big.Int {
 	}
 
 	return b
+}
+
+func (v *Value) Uint8Array() []uint8 { // TwinTag added
+	arraybytes := C.ValueToUint8Array(v.ptr)
+	arraylen := C.ValueToArrayLength(v.ptr)
+	slice := C.GoBytes(unsafe.Pointer(arraybytes), C.int(arraylen))
+	return slice
 }
 
 // Boolean perform the equivalent of `Boolean(value)` in JS. This can never fail.

--- a/value.go
+++ b/value.go
@@ -177,10 +177,9 @@ func (v *Value) BigInt() *big.Int {
 }
 
 func (v *Value) Uint8Array() []uint8 { // TwinTag added
-	arraybytes := C.ValueToUint8Array(v.ptr)
-	arraylen := C.ValueToArrayLength(v.ptr)
-	slice := C.GoBytes(unsafe.Pointer(arraybytes), C.int(arraylen))
-	return slice
+	bytes := unsafe.Pointer(C.ValueToUint8Array(v.ptr)) // allocates copy on the heap
+	defer C.free(bytes)
+	return C.GoBytes(bytes, C.int(C.ValueToArrayLength(v.ptr)))
 }
 
 // Boolean perform the equivalent of `Boolean(value)` in JS. This can never fail.

--- a/value.go
+++ b/value.go
@@ -82,6 +82,11 @@ func NewValue(iso *Isolate, val interface{}) (*Value, error) {
 		rtnVal = &Value{
 			ptr: C.NewValueNumber(iso.ptr, C.double(v)),
 		}
+	case []uint8:
+		rtnVal = &Value{
+			//NOTE: C.CBytes() allocates memory, must be freed
+			ptr: C.NewValueUint8Array(iso.ptr, (*C.uchar)(C.CBytes(v)), C.int(len(v))),
+		}
 	case *big.Int:
 		if v.IsInt64() {
 			rtnVal = &Value{

--- a/value_test.go
+++ b/value_test.go
@@ -31,6 +31,22 @@ func TestValueNewBaseCases(t *testing.T) {
 
 }
 
+func TestValueNewUint8Array(t *testing.T) {
+	t.Parallel()
+	ctx, err := v8go.NewContext()
+	if err != nil {
+		t.Fatalf("NewContext() error: %v", err)
+	}
+	iso, err := ctx.Isolate()
+	if err != nil {
+		t.Fatalf("ctx.Isolate() error: %v", err)
+	}
+	a := []uint8{1, 2, 3, 4, 5}
+	if _, err := v8go.NewValue(iso, a); err != nil {
+		t.Fatalf("Error %v", err)
+	}
+}
+
 func TestValueFormatting(t *testing.T) {
 	t.Parallel()
 	ctx, _ := v8go.NewContext(nil)

--- a/value_test.go
+++ b/value_test.go
@@ -41,9 +41,21 @@ func TestValueNewUint8Array(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ctx.Isolate() error: %v", err)
 	}
-	a := []uint8{1, 2, 3, 4, 5}
-	if _, err := v8go.NewValue(iso, a); err != nil {
+	in := []uint8{1, 2, 3, 4, 5}
+	if val, err := v8go.NewValue(iso, in); err != nil {
 		t.Fatalf("Error %v", err)
+	} else if !val.IsUint8Array() {
+		t.Errorf("Val is not []uint")
+	} else {
+		out := val.Uint8Array()
+		if len(out) != 5 {
+			t.Errorf("Expected array length 5, got %d", len(out))
+		}
+		for i := 0; i < 5; i++ {
+			if out[i] != in[i] {
+				t.Errorf("Wrong byte at %d", i)
+			}
+		}
 	}
 }
 


### PR DESCRIPTION
This PR adds code to v8go to convert []uint8 array from javascript to golang and back,
and also an Isolate method to allow throwing javascript exceptions from golang callbacks.
Test case resides in file array_test.go.
All changes have been marked with pattern "// TwinTag added" for ease of browsing, this can obviously be removed.