### PR TITLE
Implement set, get internal fields, & set internal field count

### DIFF
--- a/object.go
+++ b/object.go
@@ -27,7 +27,7 @@ func (o *Object) Set(key string, val interface{}) error {
 	if len(key) == 0 {
 		return errors.New("v8go: You must provide a valid property key")
 	}
-	return set(o, key, 0, val)
+	return set(o, key, 0, val, false)
 }
 
 // Set will set a given index on the Object to a given value.
@@ -35,10 +35,15 @@ func (o *Object) Set(key string, val interface{}) error {
 // If the value passed is a Go supported primitive (string, int32, uint32, int64, uint64, float64, big.Int)
 // then a *Value will be created and set as the value property.
 func (o *Object) SetIdx(idx uint32, val interface{}) error {
-	return set(o, "", idx, val)
+	return set(o, "", idx, val, false)
 }
 
-func set(o *Object, key string, idx uint32, val interface{}) error {
+// SetInternal sets the value of an internal field.
+func (o *Object) SetInternal(idx uint32, val interface{}) error {
+	return set(o, "", idx, val, true)
+}
+
+func set(o *Object, key string, idx uint32, val interface{}, internal bool) error {
 	var value *Value
 	switch v := val.(type) {
 	case string, int32, uint32, int64, uint64, float64, bool, *big.Int:
@@ -58,7 +63,12 @@ func set(o *Object, key string, idx uint32, val interface{}) error {
 		return nil
 	}
 
-	C.ObjectSetIdx(o.ptr, C.uint32_t(idx), value.ptr)
+	if internal {
+		C.ObjectSetInternal(o.ptr, C.uint32_t(idx), value.ptr)
+	} else {
+		C.ObjectSetIdx(o.ptr, C.uint32_t(idx), value.ptr)
+	}
+
 	return nil
 }
 
@@ -68,6 +78,12 @@ func (o *Object) Get(key string) (*Value, error) {
 	defer C.free(unsafe.Pointer(ckey))
 
 	rtn := C.ObjectGet(o.ptr, ckey)
+	return getValue(o.ctx, rtn), getError(rtn)
+}
+
+// GetInternal tries to get a Value for a given Object internal property key.
+func (o *Object) GetInternal(idx uint32) (*Value, error) {
+	rtn := C.ObjectGetInternal(o.ptr, C.uint32_t(idx))
 	return getValue(o.ctx, rtn), getError(rtn)
 }
 

--- a/object_template.go
+++ b/object_template.go
@@ -59,6 +59,12 @@ func (o *ObjectTemplate) NewInstance(ctx *Context) (*Object, error) {
 	return &Object{&Value{valPtr, ctx}}, nil
 }
 
+// SetInternalFieldCount sets the amount of internal fields that we want our
+// object to have.
+func (o *ObjectTemplate) SetInternalFieldCount(fieldCount uint32) {
+	C.ObjectTemplateSetInternalFieldCount(o.ptr, C.uint32_t(fieldCount))
+}
+
 func (o *ObjectTemplate) apply(opts *contextOptions) {
 	opts.gTmpl = o
 }

--- a/object_test.go
+++ b/object_test.go
@@ -34,6 +34,23 @@ func TestObjectSet(t *testing.T) {
 	}
 }
 
+func TestObjectPrivateProperties(t *testing.T) {
+	iso, _ := v8go.NewIsolate()
+	ctx, _ := v8go.NewContext(iso)
+
+	tmpl, _ := v8go.NewObjectTemplate(iso)
+	tmpl.SetInternalFieldCount(1)
+
+	obj, _ := tmpl.NewInstance(ctx)
+
+	obj.SetInternal(0, "baz")
+	v, err := obj.GetInternal(0)
+
+	if v.String() != "baz" || err != nil {
+		t.Errorf("unexpected value: %q", v)
+	}
+}
+
 func TestObjectGet(t *testing.T) {
 	t.Parallel()
 

--- a/v8go.cc
+++ b/v8go.cc
@@ -270,6 +270,13 @@ ValuePtr ObjectTemplateNewInstance(TemplatePtr ptr, ContextPtr ctx_ptr) {
   return tracked_value(ctx, val);
 }
 
+void ObjectTemplateSetInternalFieldCount(TemplatePtr ptr, uint32_t field_count) {
+  LOCAL_TEMPLATE(ptr);
+
+  Local<ObjectTemplate> obj_tmpl = tmpl.As<ObjectTemplate>();
+  obj_tmpl->SetInternalFieldCount(field_count);
+}
+
 /********** FunctionTemplate **********/
 
 static void FunctionTemplateCallback(const FunctionCallbackInfo<Value>& info) {
@@ -989,6 +996,13 @@ void ObjectSetIdx(ValuePtr ptr, uint32_t idx, ValuePtr val_ptr) {
   obj->Set(local_ctx, idx, prop_val->ptr.Get(iso)).Check();
 }
 
+void ObjectSetInternal(ValuePtr ptr, uint32_t idx, ValuePtr val_ptr) {
+  LOCAL_OBJECT(ptr);
+  m_value* prop_val = static_cast<m_value*>(val_ptr);
+  obj->SetAlignedPointerInInternalField(idx, nullptr);
+  obj->SetInternalField(idx, prop_val->ptr.Get(iso));
+}
+
 RtnValue ObjectGet(ValuePtr ptr, const char* key) {
   LOCAL_OBJECT(ptr);
   RtnValue rtn = {nullptr, nullptr};
@@ -996,6 +1010,25 @@ RtnValue ObjectGet(ValuePtr ptr, const char* key) {
   Local<String> key_val =
       String::NewFromUtf8(iso, key, NewStringType::kNormal).ToLocalChecked();
   MaybeLocal<Value> result = obj->Get(local_ctx, key_val);
+  if (result.IsEmpty()) {
+    rtn.error = ExceptionError(try_catch, iso, local_ctx);
+    return rtn;
+  }
+  m_value* new_val = new m_value;
+  new_val->iso = iso;
+  new_val->ctx = ctx;
+  new_val->ptr = Persistent<Value, CopyablePersistentTraits<Value>>(
+      iso, result.ToLocalChecked());
+
+  rtn.value = tracked_value(ctx, new_val);
+  return rtn;
+}
+
+RtnValue ObjectGetInternal(ValuePtr ptr, uint32_t idx) {
+  LOCAL_OBJECT(ptr);
+  RtnValue rtn = {nullptr, nullptr};
+
+  MaybeLocal<Value> result = obj->GetInternalField(idx);
   if (result.IsEmpty()) {
     rtn.error = ExceptionError(try_catch, iso, local_ctx);
     return rtn;

--- a/v8go.h
+++ b/v8go.h
@@ -78,6 +78,7 @@ extern void TemplateSetTemplate(TemplatePtr ptr,
 
 extern TemplatePtr NewObjectTemplate(IsolatePtr iso_ptr);
 extern ValuePtr ObjectTemplateNewInstance(TemplatePtr ptr, ContextPtr ctx_ptr);
+extern void ObjectTemplateSetInternalFieldCount(TemplatePtr ptr, uint32_t field_count);
 
 extern TemplatePtr NewFunctionTemplate(IsolatePtr iso_ptr, int callback_ref);
 extern ValuePtr FunctionTemplateGetFunction(TemplatePtr ptr, ContextPtr ctx_ptr);
@@ -161,8 +162,10 @@ int ValueIsModuleNamespaceObject(ValuePtr ptr);
 
 extern void ObjectSet(ValuePtr ptr, const char* key, ValuePtr val_ptr);
 extern void ObjectSetIdx(ValuePtr ptr, uint32_t idx, ValuePtr val_ptr);
+extern void ObjectSetInternal(ValuePtr ptr, uint32_t idx, ValuePtr val_ptr);
 extern RtnValue ObjectGet(ValuePtr ptr, const char* key);
 extern RtnValue ObjectGetIdx(ValuePtr ptr, uint32_t idx);
+extern RtnValue ObjectGetInternal(ValuePtr ptr, uint32_t idx);
 int ObjectHas(ValuePtr ptr, const char* key);
 int ObjectHasIdx(ValuePtr ptr, uint32_t idx);
 int ObjectDelete(ValuePtr ptr, const char* key);


### PR DESCRIPTION
I've implemented the `Object.SetInternalField`, `Object.GetInternalField`, and the `ObjectTemplate.SetInternalFieldCount` functions.

Is this a viable solution or am I missing something?

``` go
iso, _ := v8go.NewIsolate()
ctx, _ := v8go.NewContext(iso)

tmpl, _ := v8go.NewObjectTemplate(iso)
tmpl.SetInternalFieldCount(1)

obj, _ := tmpl.NewInstance(ctx)

obj.SetInternal(0, "baz")
v, err := obj.GetInternal(0)
```