### PR TITLE
refactor: Extract func coerceValue from set and remove func set

### DIFF
--- a/object_test.go
+++ b/object_test.go
@@ -62,7 +62,12 @@ func TestObjectSet(t *testing.T) {
 	if err := obj.Set("a", 0); err == nil {
 		t.Error("expected error but got <nil>")
 	}
-	obj.SetIdx(10, "ten")
+	if err := obj.SetIdx(10, "ten"); err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if err := obj.SetIdx(10, t); err == nil {
+		t.Error("expected error but got <nil>")
+	}
 	if ten, _ := ctx.RunScript("foo[10]", ""); ten.String() != "ten" {
 		t.Errorf("unexpected value: %q", ten)
 	}


### PR DESCRIPTION
cc @wisepythagoras

## Problem

https://github.com/rogchap/v8go/pull/145 is attempting to follow the current pattern of merging more code paths into `set`, which results in extra conditional complexity in `set` in order to essentially determine where it is called from and thus which argument to use.

## Solution

The common functionality in the `set` function is value coercion, so just extract that to a separate function so that we can get rid of `set`.

Note that this makes all of these functions (coerceValue, Set, SetIdx) a lot more readable in isolation.  In contrast, the call site for `set` makes it unclear why the placeholder arguments are passed in and the `set` function is harder to understand without knowing the context in which it is called from.