### PR TITLE
Function Call should support recv argument

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Removed error return value from NewContext which never fails
 - Removed error return value from Context.Isolate() which never fails
 - Removed error return value from NewObjectTemplate and NewFunctionTemplate. Panic if given a nil argument.
+- Function Call accepts receiver as first argument.
 
 ## [v0.6.0] - 2021-05-11
 

--- a/function.go
+++ b/function.go
@@ -16,7 +16,7 @@ type Function struct {
 }
 
 // Call this JavaScript function with the given arguments.
-func (fn *Function) Call(recv *Value, args ...Valuer) (*Value, error) {
+func (fn *Function) Call(recv Valuer, args ...Valuer) (*Value, error) {
 	var argptr *C.ValuePtr
 	if len(args) > 0 {
 		var cArgs = make([]C.ValuePtr, len(args))
@@ -26,7 +26,7 @@ func (fn *Function) Call(recv *Value, args ...Valuer) (*Value, error) {
 		argptr = (*C.ValuePtr)(unsafe.Pointer(&cArgs[0]))
 	}
 	fn.ctx.register()
-	rtn := C.FunctionCall(fn.ptr, recv.ptr, C.int(len(args)), argptr)
+	rtn := C.FunctionCall(fn.ptr, recv.value().ptr, C.int(len(args)), argptr)
 	fn.ctx.deregister()
 	return getValue(fn.ctx, rtn), getError(rtn)
 }

--- a/function.go
+++ b/function.go
@@ -16,7 +16,7 @@ type Function struct {
 }
 
 // Call this JavaScript function with the given arguments.
-func (fn *Function) Call(args ...Valuer) (*Value, error) {
+func (fn *Function) Call(recv *Object, args ...Valuer) (*Value, error) {
 	var argptr *C.ValuePtr
 	if len(args) > 0 {
 		var cArgs = make([]C.ValuePtr, len(args))
@@ -26,7 +26,7 @@ func (fn *Function) Call(args ...Valuer) (*Value, error) {
 		argptr = (*C.ValuePtr)(unsafe.Pointer(&cArgs[0]))
 	}
 	fn.ctx.register()
-	rtn := C.FunctionCall(fn.ptr, fn.ctx.iso.undefined.ptr, C.int(len(args)), argptr)
+	rtn := C.FunctionCall(fn.ptr, recv.ptr, C.int(len(args)), argptr)
 	fn.ctx.deregister()
 	return getValue(fn.ctx, rtn), getError(rtn)
 }

--- a/function.go
+++ b/function.go
@@ -16,7 +16,7 @@ type Function struct {
 }
 
 // Call this JavaScript function with the given arguments.
-func (fn *Function) Call(recv *Object, args ...Valuer) (*Value, error) {
+func (fn *Function) Call(recv *Value, args ...Valuer) (*Value, error) {
 	var argptr *C.ValuePtr
 	if len(args) > 0 {
 		var cArgs = make([]C.ValuePtr, len(args))

--- a/function_template_test.go
+++ b/function_template_test.go
@@ -71,7 +71,7 @@ func TestFunctionTemplateGetFunction(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	ret, err := fn.Call(ten)
+	ret, err := fn.Call(ctx.Global(), ten)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/function_template_test.go
+++ b/function_template_test.go
@@ -71,7 +71,7 @@ func TestFunctionTemplateGetFunction(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	ret, err := fn.Call(ctx.Global(), ten)
+	ret, err := fn.Call(v8go.Undefined(iso), ten)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/function_test.go
+++ b/function_test.go
@@ -84,7 +84,7 @@ func TestFunctionCallWithObjectReceiver(t *testing.T) {
 	failIf(t, err)
 	fn, err := fnVal.AsFunction()
 	failIf(t, err)
-	resultValue, err := fn.Call(obj.Value)
+	resultValue, err := fn.Call(obj)
 	failIf(t, err)
 
 	if !resultValue.IsString() || resultValue.String() != "some val" {

--- a/function_test.go
+++ b/function_test.go
@@ -27,7 +27,7 @@ func TestFunctionCall(t *testing.T) {
 	failIf(t, err)
 
 	fn, _ := addValue.AsFunction()
-	resultValue, err := fn.Call(ctx.Global(), arg1, arg1)
+	resultValue, err := fn.Call(v8go.Undefined(iso), arg1, arg1)
 	failIf(t, err)
 
 	if resultValue.Int32() != 2 {
@@ -58,7 +58,7 @@ func TestFunctionCallToGoFunc(t *testing.T) {
 	failIf(t, err)
 	fn, err := val.AsFunction()
 	failIf(t, err)
-	resultValue, err := fn.Call(ctx.Global())
+	resultValue, err := fn.Call(v8go.Undefined(iso))
 	failIf(t, err)
 
 	if !called {
@@ -84,7 +84,7 @@ func TestFunctionCallWithObjectReceiver(t *testing.T) {
 	failIf(t, err)
 	fn, err := fnVal.AsFunction()
 	failIf(t, err)
-	resultValue, err := fn.Call(obj)
+	resultValue, err := fn.Call(obj.Value)
 	failIf(t, err)
 
 	if !resultValue.IsString() || resultValue.String() != "some val" {
@@ -96,7 +96,8 @@ func TestFunctionCallError(t *testing.T) {
 	t.Parallel()
 
 	ctx := v8go.NewContext()
-	defer ctx.Isolate().Dispose()
+	iso := ctx.Isolate()
+	defer iso.Dispose()
 	defer ctx.Close()
 
 	_, err := ctx.RunScript("function throws() { throw 'error'; }", "script.js")
@@ -105,7 +106,7 @@ func TestFunctionCallError(t *testing.T) {
 	failIf(t, err)
 
 	fn, _ := addValue.AsFunction()
-	_, err = fn.Call(ctx.Global())
+	_, err = fn.Call(v8go.Undefined(iso))
 	if err == nil {
 		t.Errorf("expected an error, got none")
 	}

--- a/function_test.go
+++ b/function_test.go
@@ -27,7 +27,7 @@ func TestFunctionCall(t *testing.T) {
 	failIf(t, err)
 
 	fn, _ := addValue.AsFunction()
-	resultValue, err := fn.Call(arg1, arg1)
+	resultValue, err := fn.Call(ctx.Global(), arg1, arg1)
 	failIf(t, err)
 
 	if resultValue.Int32() != 2 {
@@ -78,7 +78,8 @@ func TestFunctionCallToGoFunc(t *testing.T) {
 		return nil
 	})
 
-	global.Set("print", printfn, v8go.ReadOnly)
+	err := global.Set("print", printfn, v8go.ReadOnly)
+	failIf(t, err)
 
 	ctx := v8go.NewContext(iso, global)
 	defer ctx.Close()
@@ -87,7 +88,7 @@ func TestFunctionCallToGoFunc(t *testing.T) {
 	failIf(t, err)
 	fn, err := val.AsFunction()
 	failIf(t, err)
-	resultValue, err := fn.Call()
+	resultValue, err := fn.Call(ctx.Global())
 	failIf(t, err)
 
 	if !called {
@@ -111,7 +112,7 @@ func TestFunctionCallError(t *testing.T) {
 	failIf(t, err)
 
 	fn, _ := addValue.AsFunction()
-	_, err = fn.Call()
+	_, err = fn.Call(ctx.Global())
 	if err == nil {
 		t.Errorf("expected an error, got none")
 	}

--- a/object.go
+++ b/object.go
@@ -32,7 +32,7 @@ func (o *Object) MethodCall(methodName string, args ...Valuer) (*Value, error) {
 	if err != nil {
 		return nil, err
 	}
-	return fn.Call(o.Value, args...)
+	return fn.Call(o, args...)
 }
 
 // Set will set a property on the Object to a given value.

--- a/object.go
+++ b/object.go
@@ -32,7 +32,7 @@ func (o *Object) MethodCall(methodName string, args ...Valuer) (*Value, error) {
 	if err != nil {
 		return nil, err
 	}
-	return fn.Call(o, args...)
+	return fn.Call(o.Value, args...)
 }
 
 // Set will set a property on the Object to a given value.

--- a/object.go
+++ b/object.go
@@ -32,19 +32,7 @@ func (o *Object) MethodCall(methodName string, args ...Valuer) (*Value, error) {
 	if err != nil {
 		return nil, err
 	}
-
-	var argptr *C.ValuePtr
-	if len(args) > 0 {
-		var cArgs = make([]C.ValuePtr, len(args))
-		for i, arg := range args {
-			cArgs[i] = arg.value().ptr
-		}
-		argptr = (*C.ValuePtr)(unsafe.Pointer(&cArgs[0]))
-	}
-	fn.ctx.register()
-	rtn := C.FunctionCall(fn.ptr, o.ptr, C.int(len(args)), argptr)
-	fn.ctx.deregister()
-	return getValue(fn.ctx, rtn), getError(rtn)
+	return fn.Call(o, args...)
 }
 
 // Set will set a property on the Object to a given value.


### PR DESCRIPTION
(cherry picked from commit 991ab091d967512721296e380a731efa08c9f85c)

Fixes https://github.com/rogchap/v8go/issues/156

The v8go library is implicitly passing `undefined` as the receiver when executing a function `Call`. To make this configurable, as shown in this PR, it would be a breaking change to the v8go api for the function object. This change ensures the explicit passing of a receiver to a function and avoid additional confusion around the fact that functions obtained from an object are not bound to the object they are obtained from. If we want to avoid the breaking change, we could instead expose something on the v8go object type called `MethodCall` which would ensure the proper execution a function/method with the object as it's receiver and avoid code like:
```
respVal, _ := ctx.Get("response")
respObj, _ := respVal.AsObject()
textVal, _ := respObj.Get("text")
textFn, _ := textVal.AsFunction()
textProm, _ := textFn.Call(respObj)
...
```

And instead may look like:
```
respVal, _ := ctx.Get("response")
respObj, _ := respVal.AsObject()
textProm, _ := respObj.MethodCall("text")
...
```

The choice is essentially - a breaking change that aligns the function call with the v8 api _or_ deviating a little from the v8 api by exposing a new method on objects.