### PR TITLE
Expose null and undefined constant values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Build v8 with i18n support
 - Access "this" from function callback
 - value.SameValue(otherValue) function to compare values for sameness
+- Undefined, Null functions to get these constant values for the isolate
 
 ### Changed
 - Removed error return value from Context.Isolate() which never fails

--- a/isolate.go
+++ b/isolate.go
@@ -22,6 +22,9 @@ type Isolate struct {
 	cbMutex sync.RWMutex
 	cbSeq   int
 	cbs     map[int]FunctionCallback
+
+	null      *Value
+	undefined *Value
 }
 
 // HeapStatistics represents V8 isolate heap statistics
@@ -54,6 +57,8 @@ func NewIsolate() (*Isolate, error) {
 		ptr: C.NewIsolate(),
 		cbs: make(map[int]FunctionCallback),
 	}
+	iso.null = newValueNull(iso)
+	iso.undefined = newValueUndefined(iso)
 	// TODO: [RC] catch any C++ exceptions and return as error
 	return iso, nil
 }

--- a/v8go.cc
+++ b/v8go.cc
@@ -569,6 +569,26 @@ ValuePtr NewValueString(IsolatePtr iso_ptr, const char* v) {
   return tracked_value(ctx, val);
 }
 
+ValuePtr NewValueNull(IsolatePtr iso_ptr) {
+  ISOLATE_SCOPE_INTERNAL_CONTEXT(iso_ptr);
+  m_value* val = new m_value;
+  val->iso = iso;
+  val->ctx = ctx;
+  val->ptr = Persistent<Value, CopyablePersistentTraits<Value>>(
+      iso, Null(iso));
+  return tracked_value(ctx, val);
+}
+
+ValuePtr NewValueUndefined(IsolatePtr iso_ptr) {
+  ISOLATE_SCOPE_INTERNAL_CONTEXT(iso_ptr);
+  m_value* val = new m_value;
+  val->iso = iso;
+  val->ctx = ctx;
+  val->ptr = Persistent<Value, CopyablePersistentTraits<Value>>(
+      iso, Undefined(iso));
+  return tracked_value(ctx, val);
+}
+
 ValuePtr NewValueBoolean(IsolatePtr iso_ptr, int v) {
   ISOLATE_SCOPE_INTERNAL_CONTEXT(iso_ptr);
   m_value* val = new m_value;

--- a/v8go.h
+++ b/v8go.h
@@ -83,6 +83,8 @@ extern TemplatePtr NewFunctionTemplate(IsolatePtr iso_ptr, int callback_ref);
 extern ValuePtr FunctionTemplateGetFunction(TemplatePtr ptr,
                                             ContextPtr ctx_ptr);
 
+extern ValuePtr NewValueNull(IsolatePtr iso_ptr);
+extern ValuePtr NewValueUndefined(IsolatePtr iso_ptr);
 extern ValuePtr NewValueInteger(IsolatePtr iso_ptr, int32_t v);
 extern ValuePtr NewValueIntegerFromUnsigned(IsolatePtr iso_ptr, uint32_t v);
 extern ValuePtr NewValueString(IsolatePtr iso_ptr, const char* v);

--- a/value.go
+++ b/value.go
@@ -31,6 +31,28 @@ func (v *Value) value() *Value {
 	return v
 }
 
+func newValueNull(iso *Isolate) *Value {
+	return &Value{
+		ptr: C.NewValueNull(iso.ptr),
+	}
+}
+
+func newValueUndefined(iso *Isolate) *Value {
+	return &Value{
+		ptr: C.NewValueUndefined(iso.ptr),
+	}
+}
+
+// Undefined returns the `undefined` JS value
+func Undefined(iso *Isolate) *Value {
+	return iso.undefined
+}
+
+// Null returns the `null` JS value
+func Null(iso *Isolate) *Value {
+	return iso.null
+}
+
 // NewValue will create a primitive value. Supported values types to create are:
 //   string -> V8::String
 //   int32 -> V8::Integer

--- a/value_test.go
+++ b/value_test.go
@@ -160,6 +160,36 @@ func TestValueBoolean(t *testing.T) {
 	}
 }
 
+func TestValueConstants(t *testing.T) {
+	t.Parallel()
+	iso, _ := v8go.NewIsolate()
+	defer iso.Dispose()
+	ctx, _ := v8go.NewContext(iso)
+	defer ctx.Close()
+
+	tests := [...]struct {
+		source string
+		value  *v8go.Value
+		same   bool
+	}{
+		{"undefined", v8go.Undefined(iso), true},
+		{"null", v8go.Null(iso), true},
+		{"undefined", v8go.Null(iso), false},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+
+		val, err := ctx.RunScript(tt.source, "test.js")
+		failIf(t, err)
+
+		if tt.value.SameValue(val) != tt.same {
+			t.Errorf("SameValue on JS `%s` and V8 value %+v didn't return %v",
+				tt.source, tt.value, tt.same)
+		}
+	}
+}
+
 func TestValueArrayIndex(t *testing.T) {
 	t.Parallel()
 	ctx, _ := v8go.NewContext(nil)


### PR DESCRIPTION
Builds on #162 
cc @genevieve 

Currently, there is no simple way of getting `null` or `undefined` JS values from v8go.  There are workarounds like running a script to get these values, but this shouldn't be necessary.

For instance, this would be useful in #160 for explicitly passing the `undefined` value as an explicit function call receiver