### PR TITLE
Removed error return value from NewIsolate & NewContext

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Support for calling a method on an object.
 
 ### Changed
+- Removed error return value from NewIsolate which never fails
 - Removed error return value from Context.Isolate() which never fails
 - Removed error return value from NewObjectTemplate and NewFunctionTemplate. Panic if given a nil argument.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - Removed error return value from NewIsolate which never fails
+- Removed error return value from NewContext which never fails
 - Removed error return value from Context.Isolate() which never fails
 - Removed error return value from NewObjectTemplate and NewFunctionTemplate. Panic if given a nil argument.
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ fmt.Printf("addition result: %s", val)
 ### One VM, many contexts
 
 ```go
-iso, _ := v8go.NewIsolate() // creates a new JavaScript VM
+iso := v8go.NewIsolate() // creates a new JavaScript VM
 ctx1, _ := v8go.NewContext(iso) // new context within the VM
 ctx1.RunScript("const multiply = (a, b) => a * b", "math.js")
 
@@ -43,7 +43,7 @@ if _, err := ctx2.RunScript("multiply(3, 4)", "main.js"); err != nil {
 ### JavaScript function with Go callback
 
 ```go
-iso, _ := v8go.NewIsolate() // create a new VM
+iso := v8go.NewIsolate() // create a new VM
 // a template that represents a JS function
 printfn := v8go.NewFunctionTemplate(iso, func(info *v8go.FunctionCallbackInfo) *v8go.Value {
     fmt.Printf("%v", info.Args()) // when the JS function is called this Go callback will execute

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ import "rogchap.com/v8go"
 ### Running a script
 
 ```go
-ctx, _ := v8go.NewContext() // creates a new V8 context with a new Isolate aka VM
+ctx := v8go.NewContext() // creates a new V8 context with a new Isolate aka VM
 ctx.RunScript("const add = (a, b) => a + b", "math.js") // executes a script on the global context
 ctx.RunScript("const result = add(3, 4)", "main.js") // any functions previously added to the context can be called
 val, _ := ctx.RunScript("result", "value.js") // return a value in JavaScript back to Go
@@ -31,10 +31,10 @@ fmt.Printf("addition result: %s", val)
 
 ```go
 iso := v8go.NewIsolate() // creates a new JavaScript VM
-ctx1, _ := v8go.NewContext(iso) // new context within the VM
+ctx1 := v8go.NewContext(iso) // new context within the VM
 ctx1.RunScript("const multiply = (a, b) => a * b", "math.js")
 
-ctx2, _ := v8go.NewContext(iso) // another context on the same VM
+ctx2 := v8go.NewContext(iso) // another context on the same VM
 if _, err := ctx2.RunScript("multiply(3, 4)", "main.js"); err != nil {
   // this will error as multiply is not defined in this context
 }
@@ -51,14 +51,14 @@ printfn := v8go.NewFunctionTemplate(iso, func(info *v8go.FunctionCallbackInfo) *
 })
 global := v8go.NewObjectTemplate(iso) // a template that represents a JS Object
 global.Set("print", printfn) // sets the "print" property of the Object to our function
-ctx, _ := v8go.NewContext(iso, global) // new Context with the global Object set to our object template
+ctx := v8go.NewContext(iso, global) // new Context with the global Object set to our object template
 ctx.RunScript("print('foo')", "print.js") // will execute the Go callback with a single argunent 'foo'
 ```
 
 ### Update a JavaScript object from Go
 
 ```go
-ctx, _ := v8go.NewContext() // new context with a default VM
+ctx := v8go.NewContext() // new context with a default VM
 obj := ctx.Global() // get the global object from the context
 obj.Set("version", "v1.0.0") // set the property "version" on the object
 val, _ := ctx.RunScript("version", "version.js") // global object will have the property set within the JS VM

--- a/context.go
+++ b/context.go
@@ -46,7 +46,7 @@ type ContextOption interface {
 
 // NewContext creates a new JavaScript context; if no Isolate is passed as a
 // ContextOption than a new Isolate will be created.
-func NewContext(opt ...ContextOption) (*Context, error) {
+func NewContext(opt ...ContextOption) *Context {
 	opts := contextOptions{}
 	for _, o := range opt {
 		if o != nil {
@@ -72,8 +72,7 @@ func NewContext(opt ...ContextOption) (*Context, error) {
 		ptr: C.NewContext(opts.iso.ptr, opts.gTmpl.ptr, C.int(ref)),
 		iso: opts.iso,
 	}
-	// TODO: [RC] catch any C++ exceptions and return as error
-	return ctx, nil
+	return ctx
 }
 
 // Isolate gets the current context's parent isolate.An  error is returned

--- a/context.go
+++ b/context.go
@@ -8,7 +8,6 @@ package v8go
 // #include "v8go.h"
 import "C"
 import (
-	"fmt"
 	"sync"
 	"unsafe"
 )
@@ -56,11 +55,7 @@ func NewContext(opt ...ContextOption) (*Context, error) {
 	}
 
 	if opts.iso == nil {
-		var err error
-		opts.iso, err = NewIsolate()
-		if err != nil {
-			return nil, fmt.Errorf("v8go: failed to create new Isolate: %v", err)
-		}
+		opts.iso = NewIsolate()
 	}
 
 	if opts.gTmpl == nil {

--- a/context_test.go
+++ b/context_test.go
@@ -103,7 +103,7 @@ func TestContextRegistry(t *testing.T) {
 func TestMemoryLeak(t *testing.T) {
 	t.Parallel()
 
-	iso, _ := v8go.NewIsolate()
+	iso := v8go.NewIsolate()
 	defer iso.Dispose()
 
 	for i := 0; i < 6000; i++ {
@@ -120,7 +120,7 @@ func TestMemoryLeak(t *testing.T) {
 
 func BenchmarkContext(b *testing.B) {
 	b.ReportAllocs()
-	iso, _ := v8go.NewIsolate()
+	iso := v8go.NewIsolate()
 	defer iso.Dispose()
 	for n := 0; n < b.N; n++ {
 		ctx, _ := v8go.NewContext(iso)
@@ -145,7 +145,7 @@ func ExampleContext() {
 }
 
 func ExampleContext_isolate() {
-	iso, _ := v8go.NewIsolate()
+	iso := v8go.NewIsolate()
 	defer iso.Dispose()
 	ctx1, _ := v8go.NewContext(iso)
 	defer ctx1.Close()
@@ -163,7 +163,7 @@ func ExampleContext_isolate() {
 }
 
 func ExampleContext_globalTemplate() {
-	iso, _ := v8go.NewIsolate()
+	iso := v8go.NewIsolate()
 	defer iso.Dispose()
 	obj := v8go.NewObjectTemplate(iso)
 	obj.Set("version", "v1.0.0")

--- a/context_test.go
+++ b/context_test.go
@@ -14,7 +14,7 @@ import (
 
 func TestContextExec(t *testing.T) {
 	t.Parallel()
-	ctx, _ := v8go.NewContext(nil)
+	ctx := v8go.NewContext(nil)
 	defer ctx.Isolate().Dispose()
 	defer ctx.Close()
 
@@ -31,7 +31,7 @@ func TestContextExec(t *testing.T) {
 	}
 
 	iso := ctx.Isolate()
-	ctx2, _ := v8go.NewContext(iso)
+	ctx2 := v8go.NewContext(iso)
 	_, err = ctx2.RunScript(`add`, "ctx2.js")
 	if err == nil {
 		t.Error("error expected but was <nil>")
@@ -51,7 +51,7 @@ func TestJSExceptions(t *testing.T) {
 		{"ReferenceError", "add()", "add.js", "ReferenceError: add is not defined"},
 	}
 
-	ctx, _ := v8go.NewContext(nil)
+	ctx := v8go.NewContext(nil)
 	defer ctx.Isolate().Dispose()
 	defer ctx.Close()
 
@@ -73,7 +73,7 @@ func TestJSExceptions(t *testing.T) {
 func TestContextRegistry(t *testing.T) {
 	t.Parallel()
 
-	ctx, _ := v8go.NewContext()
+	ctx := v8go.NewContext()
 	defer ctx.Isolate().Dispose()
 	defer ctx.Close()
 
@@ -107,7 +107,7 @@ func TestMemoryLeak(t *testing.T) {
 	defer iso.Dispose()
 
 	for i := 0; i < 6000; i++ {
-		ctx, _ := v8go.NewContext(iso)
+		ctx := v8go.NewContext(iso)
 		obj := ctx.Global()
 		_ = obj.String()
 		_, _ = ctx.RunScript("2", "")
@@ -123,7 +123,7 @@ func BenchmarkContext(b *testing.B) {
 	iso := v8go.NewIsolate()
 	defer iso.Dispose()
 	for n := 0; n < b.N; n++ {
-		ctx, _ := v8go.NewContext(iso)
+		ctx := v8go.NewContext(iso)
 		ctx.RunScript(script, "main.js")
 		str, _ := json.Marshal(makeObject())
 		cmd := fmt.Sprintf("process(%s)", str)
@@ -133,7 +133,7 @@ func BenchmarkContext(b *testing.B) {
 }
 
 func ExampleContext() {
-	ctx, _ := v8go.NewContext()
+	ctx := v8go.NewContext()
 	defer ctx.Isolate().Dispose()
 	defer ctx.Close()
 	ctx.RunScript("const add = (a, b) => a + b", "math.js")
@@ -147,13 +147,13 @@ func ExampleContext() {
 func ExampleContext_isolate() {
 	iso := v8go.NewIsolate()
 	defer iso.Dispose()
-	ctx1, _ := v8go.NewContext(iso)
+	ctx1 := v8go.NewContext(iso)
 	defer ctx1.Close()
 	ctx1.RunScript("const foo = 'bar'", "context_one.js")
 	val, _ := ctx1.RunScript("foo", "foo.js")
 	fmt.Println(val)
 
-	ctx2, _ := v8go.NewContext(iso)
+	ctx2 := v8go.NewContext(iso)
 	defer ctx2.Close()
 	_, err := ctx2.RunScript("foo", "context_two.js")
 	fmt.Println(err)
@@ -167,7 +167,7 @@ func ExampleContext_globalTemplate() {
 	defer iso.Dispose()
 	obj := v8go.NewObjectTemplate(iso)
 	obj.Set("version", "v1.0.0")
-	ctx, _ := v8go.NewContext(iso, obj)
+	ctx := v8go.NewContext(iso, obj)
 	defer ctx.Close()
 	val, _ := ctx.RunScript("version", "main.js")
 	fmt.Println(val)

--- a/errors_test.go
+++ b/errors_test.go
@@ -47,7 +47,7 @@ func TestErrorFormatting(t *testing.T) {
 
 func TestJSErrorOutput(t *testing.T) {
 	t.Parallel()
-	ctx, _ := v8go.NewContext(nil)
+	ctx := v8go.NewContext(nil)
 	defer ctx.Isolate().Dispose()
 	defer ctx.Close()
 

--- a/function_template_test.go
+++ b/function_template_test.go
@@ -17,7 +17,7 @@ import (
 func TestFunctionTemplate(t *testing.T) {
 	t.Parallel()
 
-	iso, _ := v8go.NewIsolate()
+	iso := v8go.NewIsolate()
 	defer iso.Dispose()
 	fn := v8go.NewFunctionTemplate(iso, func(*v8go.FunctionCallbackInfo) *v8go.Value { return nil })
 	if fn == nil {
@@ -47,7 +47,7 @@ func TestFunctionTemplate_panic_on_nil_callback(t *testing.T) {
 			t.Error("expected panic")
 		}
 	}()
-	iso, _ := v8go.NewIsolate()
+	iso := v8go.NewIsolate()
 	defer iso.Dispose()
 	v8go.NewFunctionTemplate(iso, nil)
 }
@@ -55,7 +55,7 @@ func TestFunctionTemplate_panic_on_nil_callback(t *testing.T) {
 func TestFunctionTemplateGetFunction(t *testing.T) {
 	t.Parallel()
 
-	iso, _ := v8go.NewIsolate()
+	iso := v8go.NewIsolate()
 	defer iso.Dispose()
 	ctx, _ := v8go.NewContext(iso)
 	defer ctx.Close()
@@ -86,7 +86,7 @@ func TestFunctionTemplateGetFunction(t *testing.T) {
 func TestFunctionCallbackInfoThis(t *testing.T) {
 	t.Parallel()
 
-	iso, _ := v8go.NewIsolate()
+	iso := v8go.NewIsolate()
 
 	foo := v8go.NewObjectTemplate(iso)
 	foo.Set("name", "foobar")
@@ -111,7 +111,7 @@ func TestFunctionCallbackInfoThis(t *testing.T) {
 }
 
 func ExampleFunctionTemplate() {
-	iso, _ := v8go.NewIsolate()
+	iso := v8go.NewIsolate()
 	defer iso.Dispose()
 	global := v8go.NewObjectTemplate(iso)
 	printfn := v8go.NewFunctionTemplate(iso, func(info *v8go.FunctionCallbackInfo) *v8go.Value {
@@ -127,7 +127,7 @@ func ExampleFunctionTemplate() {
 }
 
 func ExampleFunctionTemplate_fetch() {
-	iso, _ := v8go.NewIsolate()
+	iso := v8go.NewIsolate()
 	defer iso.Dispose()
 	global := v8go.NewObjectTemplate(iso)
 

--- a/function_template_test.go
+++ b/function_template_test.go
@@ -57,7 +57,7 @@ func TestFunctionTemplateGetFunction(t *testing.T) {
 
 	iso := v8go.NewIsolate()
 	defer iso.Dispose()
-	ctx, _ := v8go.NewContext(iso)
+	ctx := v8go.NewContext(iso)
 	defer ctx.Close()
 
 	var args *v8go.FunctionCallbackInfo
@@ -101,7 +101,7 @@ func TestFunctionCallbackInfoThis(t *testing.T) {
 	global := v8go.NewObjectTemplate(iso)
 	global.Set("foo", foo)
 
-	ctx, _ := v8go.NewContext(iso, global)
+	ctx := v8go.NewContext(iso, global)
 	ctx.RunScript("foo.bar()", "")
 
 	v, _ := this.Get("name")
@@ -119,7 +119,7 @@ func ExampleFunctionTemplate() {
 		return nil
 	})
 	global.Set("print", printfn, v8go.ReadOnly)
-	ctx, _ := v8go.NewContext(iso, global)
+	ctx := v8go.NewContext(iso, global)
 	defer ctx.Close()
 	ctx.RunScript("print('foo', 'bar', 0, 1)", "")
 	// Output:
@@ -147,7 +147,7 @@ func ExampleFunctionTemplate_fetch() {
 	})
 	global.Set("fetch", fetchfn, v8go.ReadOnly)
 
-	ctx, _ := v8go.NewContext(iso, global)
+	ctx := v8go.NewContext(iso, global)
 	defer ctx.Close()
 	val, _ := ctx.RunScript("fetch('https://rogchap.com/v8go')", "")
 	prom, _ := val.AsPromise()

--- a/function_test.go
+++ b/function_test.go
@@ -70,7 +70,7 @@ func TestFunctionSourceMapUrl(t *testing.T) {
 func TestFunctionCallToGoFunc(t *testing.T) {
 	t.Parallel()
 
-	iso, _ := v8go.NewIsolate()
+	iso := v8go.NewIsolate()
 	defer iso.Dispose()
 	global := v8go.NewObjectTemplate(iso)
 

--- a/function_test.go
+++ b/function_test.go
@@ -13,12 +13,11 @@ import (
 func TestFunctionCall(t *testing.T) {
 	t.Parallel()
 
-	ctx, err := v8go.NewContext()
-	failIf(t, err)
+	ctx := v8go.NewContext()
 	defer ctx.Isolate().Dispose()
 	defer ctx.Close()
 
-	_, err = ctx.RunScript("function add(a, b) { return a + b; }", "")
+	_, err := ctx.RunScript("function add(a, b) { return a + b; }", "")
 	failIf(t, err)
 	addValue, err := ctx.Global().Get("add")
 	failIf(t, err)
@@ -39,11 +38,10 @@ func TestFunctionCall(t *testing.T) {
 func TestFunctionSourceMapUrl(t *testing.T) {
 	t.Parallel()
 
-	ctx, err := v8go.NewContext()
-	failIf(t, err)
+	ctx := v8go.NewContext()
 	defer ctx.Isolate().Dispose()
 	defer ctx.Close()
-	_, err = ctx.RunScript("function add(a, b) { return a + b; }; //# sourceMappingURL=main.js.map", "main.js")
+	_, err := ctx.RunScript("function add(a, b) { return a + b; }; //# sourceMappingURL=main.js.map", "main.js")
 	failIf(t, err)
 	addValue, err := ctx.Global().Get("add")
 	failIf(t, err)
@@ -82,8 +80,7 @@ func TestFunctionCallToGoFunc(t *testing.T) {
 
 	global.Set("print", printfn, v8go.ReadOnly)
 
-	ctx, err := v8go.NewContext(iso, global)
-	failIf(t, err)
+	ctx := v8go.NewContext(iso, global)
 	defer ctx.Close()
 
 	val, err := ctx.RunScript(`(a, b) => { print("foo"); }`, "")
@@ -104,12 +101,11 @@ func TestFunctionCallToGoFunc(t *testing.T) {
 func TestFunctionCallError(t *testing.T) {
 	t.Parallel()
 
-	ctx, err := v8go.NewContext()
-	failIf(t, err)
+	ctx := v8go.NewContext()
 	defer ctx.Isolate().Dispose()
 	defer ctx.Close()
 
-	_, err = ctx.RunScript("function throws() { throw 'error'; }", "script.js")
+	_, err := ctx.RunScript("function throws() { throw 'error'; }", "script.js")
 	failIf(t, err)
 	addValue, err := ctx.Global().Get("throws")
 	failIf(t, err)
@@ -129,8 +125,7 @@ func TestFunctionCallError(t *testing.T) {
 func TestFunctionNewInstance(t *testing.T) {
 	t.Parallel()
 
-	ctx, err := v8go.NewContext()
-	failIf(t, err)
+	ctx := v8go.NewContext()
 	defer ctx.Isolate().Dispose()
 	defer ctx.Close()
 
@@ -160,12 +155,11 @@ func TestFunctionNewInstance(t *testing.T) {
 func TestFunctionNewInstanceError(t *testing.T) {
 	t.Parallel()
 
-	ctx, err := v8go.NewContext()
-	failIf(t, err)
+	ctx := v8go.NewContext()
 	defer ctx.Isolate().Dispose()
 	defer ctx.Close()
 
-	_, err = ctx.RunScript("function throws() { throw 'error'; }", "script.js")
+	_, err := ctx.RunScript("function throws() { throw 'error'; }", "script.js")
 	failIf(t, err)
 	throwsValue, err := ctx.Global().Get("throws")
 	failIf(t, err)

--- a/isolate.go
+++ b/isolate.go
@@ -49,7 +49,7 @@ type HeapStatistics struct {
 // by calling iso.Dispose().
 // An *Isolate can be used as a v8go.ContextOption to create a new
 // Context, rather than creating a new default Isolate.
-func NewIsolate() (*Isolate, error) {
+func NewIsolate() *Isolate {
 	v8once.Do(func() {
 		C.Init()
 	})
@@ -59,8 +59,7 @@ func NewIsolate() (*Isolate, error) {
 	}
 	iso.null = newValueNull(iso)
 	iso.undefined = newValueUndefined(iso)
-	// TODO: [RC] catch any C++ exceptions and return as error
-	return iso, nil
+	return iso
 }
 
 // TerminateExecution terminates forcefully the current thread

--- a/isolate_test.go
+++ b/isolate_test.go
@@ -18,7 +18,7 @@ import (
 
 func TestIsolateTermination(t *testing.T) {
 	t.Parallel()
-	iso, _ := v8go.NewIsolate()
+	iso := v8go.NewIsolate()
 	defer iso.Dispose()
 	ctx, _ := v8go.NewContext(iso)
 	defer ctx.Close()
@@ -44,7 +44,7 @@ func TestIsolateTermination(t *testing.T) {
 
 func TestGetHeapStatistics(t *testing.T) {
 	t.Parallel()
-	iso, _ := v8go.NewIsolate()
+	iso := v8go.NewIsolate()
 	defer iso.Dispose()
 	ctx1, _ := v8go.NewContext(iso)
 	defer ctx1.Close()
@@ -65,7 +65,7 @@ func TestGetHeapStatistics(t *testing.T) {
 func TestCallbackRegistry(t *testing.T) {
 	t.Parallel()
 
-	iso, _ := v8go.NewIsolate()
+	iso := v8go.NewIsolate()
 	defer iso.Dispose()
 	cb := func(*v8go.FunctionCallbackInfo) *v8go.Value { return nil }
 
@@ -86,7 +86,7 @@ func TestCallbackRegistry(t *testing.T) {
 func TestIsolateDispose(t *testing.T) {
 	t.Parallel()
 
-	iso, _ := v8go.NewIsolate()
+	iso := v8go.NewIsolate()
 	if iso.GetHeapStatistics().TotalHeapSize == 0 {
 		t.Error("Isolate incorrectly allocated")
 	}
@@ -105,7 +105,7 @@ func TestIsolateDispose(t *testing.T) {
 func TestIsolateGarbageCollection(t *testing.T) {
 	t.Parallel()
 
-	iso, _ := v8go.NewIsolate()
+	iso := v8go.NewIsolate()
 	val, _ := v8go.NewValue(iso, "some string")
 	fmt.Println(val.String())
 
@@ -123,7 +123,7 @@ func TestIsolateGarbageCollection(t *testing.T) {
 func BenchmarkIsolateInitialization(b *testing.B) {
 	b.ReportAllocs()
 	for n := 0; n < b.N; n++ {
-		vm, _ := v8go.NewIsolate()
+		vm := v8go.NewIsolate()
 		vm.Close() // force disposal of the VM
 	}
 }
@@ -131,7 +131,7 @@ func BenchmarkIsolateInitialization(b *testing.B) {
 func BenchmarkIsolateInitAndRun(b *testing.B) {
 	b.ReportAllocs()
 	for n := 0; n < b.N; n++ {
-		vm, _ := v8go.NewIsolate()
+		vm := v8go.NewIsolate()
 		ctx, _ := v8go.NewContext(vm)
 		ctx.RunScript(script, "main.js")
 		str, _ := json.Marshal(makeObject())

--- a/isolate_test.go
+++ b/isolate_test.go
@@ -22,7 +22,6 @@ func TestIsolateTermination(t *testing.T) {
 	defer iso.Dispose()
 	ctx := v8go.NewContext(iso)
 	defer ctx.Close()
-	//	ctx2 := v8go.NewContext(iso)
 
 	err := make(chan error, 1)
 

--- a/isolate_test.go
+++ b/isolate_test.go
@@ -20,9 +20,9 @@ func TestIsolateTermination(t *testing.T) {
 	t.Parallel()
 	iso := v8go.NewIsolate()
 	defer iso.Dispose()
-	ctx, _ := v8go.NewContext(iso)
+	ctx := v8go.NewContext(iso)
 	defer ctx.Close()
-	//	ctx2, _ := v8go.NewContext(iso)
+	//	ctx2 := v8go.NewContext(iso)
 
 	err := make(chan error, 1)
 
@@ -46,9 +46,9 @@ func TestGetHeapStatistics(t *testing.T) {
 	t.Parallel()
 	iso := v8go.NewIsolate()
 	defer iso.Dispose()
-	ctx1, _ := v8go.NewContext(iso)
+	ctx1 := v8go.NewContext(iso)
 	defer ctx1.Close()
-	ctx2, _ := v8go.NewContext(iso)
+	ctx2 := v8go.NewContext(iso)
 	defer ctx2.Close()
 
 	hs := iso.GetHeapStatistics()
@@ -132,7 +132,7 @@ func BenchmarkIsolateInitAndRun(b *testing.B) {
 	b.ReportAllocs()
 	for n := 0; n < b.N; n++ {
 		vm := v8go.NewIsolate()
-		ctx, _ := v8go.NewContext(vm)
+		ctx := v8go.NewContext(vm)
 		ctx.RunScript(script, "main.js")
 		str, _ := json.Marshal(makeObject())
 		cmd := fmt.Sprintf("process(%s)", str)

--- a/json_test.go
+++ b/json_test.go
@@ -17,7 +17,7 @@ func TestJSONParse(t *testing.T) {
 	if _, err := v8go.JSONParse(nil, "{}"); err == nil {
 		t.Error("expected error but got <nil>")
 	}
-	ctx, _ := v8go.NewContext()
+	ctx := v8go.NewContext()
 	defer ctx.Isolate().Dispose()
 	defer ctx.Close()
 	_, err := v8go.JSONParse(ctx, "{")
@@ -34,7 +34,7 @@ func TestJSONParse(t *testing.T) {
 func TestJSONStringify(t *testing.T) {
 	t.Parallel()
 
-	ctx, _ := v8go.NewContext()
+	ctx := v8go.NewContext()
 	defer ctx.Isolate().Dispose()
 	defer ctx.Close()
 	if _, err := v8go.JSONStringify(ctx, nil); err == nil {
@@ -43,7 +43,7 @@ func TestJSONStringify(t *testing.T) {
 }
 
 func ExampleJSONParse() {
-	ctx, _ := v8go.NewContext()
+	ctx := v8go.NewContext()
 	defer ctx.Isolate().Dispose()
 	defer ctx.Close()
 	val, _ := v8go.JSONParse(ctx, `{"foo": "bar"}`)
@@ -53,7 +53,7 @@ func ExampleJSONParse() {
 }
 
 func ExampleJSONStringify() {
-	ctx, _ := v8go.NewContext()
+	ctx := v8go.NewContext()
 	defer ctx.Isolate().Dispose()
 	defer ctx.Close()
 	val, _ := v8go.JSONParse(ctx, `{

--- a/object_template_test.go
+++ b/object_template_test.go
@@ -13,7 +13,7 @@ import (
 
 func TestObjectTemplate(t *testing.T) {
 	t.Parallel()
-	iso, _ := v8go.NewIsolate()
+	iso := v8go.NewIsolate()
 	defer iso.Dispose()
 	obj := v8go.NewObjectTemplate(iso)
 
@@ -68,7 +68,7 @@ func TestObjectTemplate_panic_on_nil_isolate(t *testing.T) {
 
 func TestGlobalObjectTemplate(t *testing.T) {
 	t.Parallel()
-	iso, _ := v8go.NewIsolate()
+	iso := v8go.NewIsolate()
 	defer iso.Dispose()
 	tests := [...]struct {
 		global   func() *v8go.ObjectTemplate
@@ -125,7 +125,7 @@ func TestGlobalObjectTemplate(t *testing.T) {
 
 func TestObjectTemplateNewInstance(t *testing.T) {
 	t.Parallel()
-	iso, _ := v8go.NewIsolate()
+	iso := v8go.NewIsolate()
 	defer iso.Dispose()
 	tmpl := v8go.NewObjectTemplate(iso)
 	if _, err := tmpl.NewInstance(nil); err == nil {

--- a/object_template_test.go
+++ b/object_template_test.go
@@ -112,7 +112,7 @@ func TestGlobalObjectTemplate(t *testing.T) {
 	for _, tt := range tests {
 		tt := tt
 		t.Run(tt.source, func(t *testing.T) {
-			ctx, _ := v8go.NewContext(iso, tt.global())
+			ctx := v8go.NewContext(iso, tt.global())
 			val, err := ctx.RunScript(tt.source, "test.js")
 			if err != nil {
 				t.Fatalf("unexpected error runing script: %v", err)
@@ -133,7 +133,7 @@ func TestObjectTemplateNewInstance(t *testing.T) {
 	}
 
 	tmpl.Set("foo", "bar")
-	ctx, _ := v8go.NewContext(iso)
+	ctx := v8go.NewContext(iso)
 	defer ctx.Close()
 	obj, _ := tmpl.NewInstance(ctx)
 	if foo, _ := obj.Get("foo"); foo.String() != "bar" {

--- a/object_test.go
+++ b/object_test.go
@@ -14,7 +14,7 @@ import (
 func TestObjectMethodCall(t *testing.T) {
 	t.Parallel()
 
-	ctx, _ := v8go.NewContext()
+	ctx := v8go.NewContext()
 	iso := ctx.Isolate()
 	val, _ := ctx.RunScript(`class Obj { constructor(input) { this.input = input, this.prop = "" } print() { return this.input.toString() } }; new Obj("some val")`, "")
 	obj, _ := val.AsObject()
@@ -46,7 +46,7 @@ func TestObjectMethodCall(t *testing.T) {
 func TestObjectSet(t *testing.T) {
 	t.Parallel()
 
-	ctx, _ := v8go.NewContext()
+	ctx := v8go.NewContext()
 	defer ctx.Isolate().Dispose()
 	defer ctx.Close()
 	val, _ := ctx.RunScript("const foo = {}; foo", "")
@@ -71,7 +71,7 @@ func TestObjectSet(t *testing.T) {
 func TestObjectGet(t *testing.T) {
 	t.Parallel()
 
-	ctx, _ := v8go.NewContext()
+	ctx := v8go.NewContext()
 	defer ctx.Isolate().Dispose()
 	defer ctx.Close()
 	val, _ := ctx.RunScript("const foo = { bar: 'baz'}; foo", "")
@@ -94,7 +94,7 @@ func TestObjectGet(t *testing.T) {
 func TestObjectHas(t *testing.T) {
 	t.Parallel()
 
-	ctx, _ := v8go.NewContext()
+	ctx := v8go.NewContext()
 	defer ctx.Isolate().Dispose()
 	defer ctx.Close()
 	val, _ := ctx.RunScript("const foo = {a: 1, '2': 2}; foo", "")
@@ -116,7 +116,7 @@ func TestObjectHas(t *testing.T) {
 func TestObjectDelete(t *testing.T) {
 	t.Parallel()
 
-	ctx, _ := v8go.NewContext()
+	ctx := v8go.NewContext()
 	defer ctx.Isolate().Dispose()
 	defer ctx.Close()
 	val, _ := ctx.RunScript("const foo = { bar: 'baz', '2': 2}; foo", "")
@@ -139,7 +139,7 @@ func TestObjectDelete(t *testing.T) {
 func ExampleObject_global() {
 	iso := v8go.NewIsolate()
 	defer iso.Dispose()
-	ctx, _ := v8go.NewContext(iso)
+	ctx := v8go.NewContext(iso)
 	defer ctx.Close()
 	global := ctx.Global()
 

--- a/object_test.go
+++ b/object_test.go
@@ -137,7 +137,7 @@ func TestObjectDelete(t *testing.T) {
 }
 
 func ExampleObject_global() {
-	iso, _ := v8go.NewIsolate()
+	iso := v8go.NewIsolate()
 	defer iso.Dispose()
 	ctx, _ := v8go.NewContext(iso)
 	defer ctx.Close()

--- a/promise_test.go
+++ b/promise_test.go
@@ -15,7 +15,7 @@ func TestPromiseFulfilled(t *testing.T) {
 
 	iso := v8go.NewIsolate()
 	defer iso.Dispose()
-	ctx, _ := v8go.NewContext(iso)
+	ctx := v8go.NewContext(iso)
 	defer ctx.Close()
 
 	if _, err := v8go.NewPromiseResolver(nil); err == nil {
@@ -65,7 +65,7 @@ func TestPromiseRejected(t *testing.T) {
 
 	iso := v8go.NewIsolate()
 	defer iso.Dispose()
-	ctx, _ := v8go.NewContext(iso)
+	ctx := v8go.NewContext(iso)
 	defer ctx.Close()
 
 	res2, _ := v8go.NewPromiseResolver(ctx)
@@ -115,7 +115,7 @@ func TestPromiseThenPanic(t *testing.T) {
 
 	iso := v8go.NewIsolate()
 	defer iso.Dispose()
-	ctx, _ := v8go.NewContext(iso)
+	ctx := v8go.NewContext(iso)
 	defer ctx.Close()
 
 	res, _ := v8go.NewPromiseResolver(ctx)

--- a/promise_test.go
+++ b/promise_test.go
@@ -13,7 +13,7 @@ import (
 func TestPromiseFulfilled(t *testing.T) {
 	t.Parallel()
 
-	iso, _ := v8go.NewIsolate()
+	iso := v8go.NewIsolate()
 	defer iso.Dispose()
 	ctx, _ := v8go.NewContext(iso)
 	defer ctx.Close()
@@ -63,7 +63,7 @@ func TestPromiseFulfilled(t *testing.T) {
 func TestPromiseRejected(t *testing.T) {
 	t.Parallel()
 
-	iso, _ := v8go.NewIsolate()
+	iso := v8go.NewIsolate()
 	defer iso.Dispose()
 	ctx, _ := v8go.NewContext(iso)
 	defer ctx.Close()
@@ -113,7 +113,7 @@ func TestPromiseRejected(t *testing.T) {
 func TestPromiseThenPanic(t *testing.T) {
 	t.Parallel()
 
-	iso, _ := v8go.NewIsolate()
+	iso := v8go.NewIsolate()
 	defer iso.Dispose()
 	ctx, _ := v8go.NewContext(iso)
 	defer ctx.Close()

--- a/v8go_test.go
+++ b/v8go_test.go
@@ -22,7 +22,7 @@ func TestVersion(t *testing.T) {
 
 func TestSetFlag(t *testing.T) {
 	t.Parallel()
-	ctx, _ := v8go.NewContext()
+	ctx := v8go.NewContext()
 	defer ctx.Isolate().Dispose()
 	defer ctx.Close()
 	if _, err := ctx.RunScript("a = 1", "default.js"); err != nil {

--- a/value_test.go
+++ b/value_test.go
@@ -34,7 +34,7 @@ func TestValueNewBaseCases(t *testing.T) {
 
 func TestValueFormatting(t *testing.T) {
 	t.Parallel()
-	ctx, _ := v8go.NewContext(nil)
+	ctx := v8go.NewContext(nil)
 	defer ctx.Isolate().Dispose()
 	defer ctx.Close()
 
@@ -70,7 +70,7 @@ func TestValueFormatting(t *testing.T) {
 
 func TestValueString(t *testing.T) {
 	t.Parallel()
-	ctx, _ := v8go.NewContext(nil)
+	ctx := v8go.NewContext(nil)
 	defer ctx.Isolate().Dispose()
 	defer ctx.Close()
 
@@ -99,7 +99,7 @@ func TestValueString(t *testing.T) {
 
 func TestValueDetailString(t *testing.T) {
 	t.Parallel()
-	ctx, _ := v8go.NewContext(nil)
+	ctx := v8go.NewContext(nil)
 	defer ctx.Isolate().Dispose()
 	defer ctx.Close()
 
@@ -128,7 +128,7 @@ func TestValueDetailString(t *testing.T) {
 
 func TestValueBoolean(t *testing.T) {
 	t.Parallel()
-	ctx, _ := v8go.NewContext(nil)
+	ctx := v8go.NewContext(nil)
 	defer ctx.Isolate().Dispose()
 	defer ctx.Close()
 
@@ -164,7 +164,7 @@ func TestValueConstants(t *testing.T) {
 	t.Parallel()
 	iso := v8go.NewIsolate()
 	defer iso.Dispose()
-	ctx, _ := v8go.NewContext(iso)
+	ctx := v8go.NewContext(iso)
 	defer ctx.Close()
 
 	tests := [...]struct {
@@ -192,7 +192,7 @@ func TestValueConstants(t *testing.T) {
 
 func TestValueArrayIndex(t *testing.T) {
 	t.Parallel()
-	ctx, _ := v8go.NewContext(nil)
+	ctx := v8go.NewContext(nil)
 	defer ctx.Isolate().Dispose()
 	defer ctx.Close()
 
@@ -230,7 +230,7 @@ func TestValueArrayIndex(t *testing.T) {
 
 func TestValueInt32(t *testing.T) {
 	t.Parallel()
-	ctx, _ := v8go.NewContext(nil)
+	ctx := v8go.NewContext(nil)
 	defer ctx.Isolate().Dispose()
 	defer ctx.Close()
 
@@ -269,7 +269,7 @@ func TestValueInt32(t *testing.T) {
 
 func TestValueInteger(t *testing.T) {
 	t.Parallel()
-	ctx, _ := v8go.NewContext(nil)
+	ctx := v8go.NewContext(nil)
 	defer ctx.Isolate().Dispose()
 	defer ctx.Close()
 
@@ -308,7 +308,7 @@ func TestValueInteger(t *testing.T) {
 
 func TestValueNumber(t *testing.T) {
 	t.Parallel()
-	ctx, _ := v8go.NewContext(nil)
+	ctx := v8go.NewContext(nil)
 	defer ctx.Isolate().Dispose()
 	defer ctx.Close()
 
@@ -352,7 +352,7 @@ func TestValueNumber(t *testing.T) {
 
 func TestValueUint32(t *testing.T) {
 	t.Parallel()
-	ctx, _ := v8go.NewContext(nil)
+	ctx := v8go.NewContext(nil)
 	defer ctx.Isolate().Dispose()
 	defer ctx.Close()
 
@@ -399,7 +399,7 @@ func TestValueBigInt(t *testing.T) {
 	for _, tt := range tests {
 		tt := tt
 		t.Run(tt.source, func(t *testing.T) {
-			ctx, _ := v8go.NewContext(iso)
+			ctx := v8go.NewContext(iso)
 			defer ctx.Close()
 
 			val, _ := ctx.RunScript(tt.source, "test.js")
@@ -422,7 +422,7 @@ func TestValueBigInt(t *testing.T) {
 func TestValueObject(t *testing.T) {
 	t.Parallel()
 
-	ctx, _ := v8go.NewContext()
+	ctx := v8go.NewContext()
 	defer ctx.Isolate().Dispose()
 	defer ctx.Close()
 
@@ -438,7 +438,7 @@ func TestValueObject(t *testing.T) {
 func TestValuePromise(t *testing.T) {
 	t.Parallel()
 
-	ctx, _ := v8go.NewContext()
+	ctx := v8go.NewContext()
 	defer ctx.Isolate().Dispose()
 	defer ctx.Close()
 
@@ -455,7 +455,7 @@ func TestValuePromise(t *testing.T) {
 func TestValueFunction(t *testing.T) {
 	t.Parallel()
 
-	ctx, _ := v8go.NewContext()
+	ctx := v8go.NewContext()
 	defer ctx.Isolate().Dispose()
 	defer ctx.Close()
 
@@ -477,7 +477,7 @@ func TestValueSameValue(t *testing.T) {
 	t.Parallel()
 	iso := v8go.NewIsolate()
 	defer iso.Dispose()
-	ctx, _ := v8go.NewContext(iso)
+	ctx := v8go.NewContext(iso)
 	defer ctx.Close()
 
 	objTempl := v8go.NewObjectTemplate(iso)
@@ -596,7 +596,7 @@ func TestValueIsXXX(t *testing.T) {
 	for _, tt := range tests {
 		tt := tt
 		t.Run(tt.source, func(t *testing.T) {
-			ctx, _ := v8go.NewContext(iso)
+			ctx := v8go.NewContext(iso)
 			defer ctx.Close()
 
 			val, err := ctx.RunScript(tt.source, "test.js")
@@ -654,7 +654,7 @@ func TestValueMarshalJSON(t *testing.T) {
 	for _, tt := range tests {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
-			ctx, _ := v8go.NewContext(iso)
+			ctx := v8go.NewContext(iso)
 			defer ctx.Close()
 			val := tt.val(ctx)
 			json, _ := val.MarshalJSON()

--- a/value_test.go
+++ b/value_test.go
@@ -21,7 +21,7 @@ func TestValueNewBaseCases(t *testing.T) {
 	if _, err := v8go.NewValue(nil, ""); err == nil {
 		t.Error("expected error, but got <nil>")
 	}
-	iso, _ := v8go.NewIsolate()
+	iso := v8go.NewIsolate()
 	defer iso.Dispose()
 	if _, err := v8go.NewValue(iso, nil); err == nil {
 		t.Error("expected error, but got <nil>")
@@ -162,7 +162,7 @@ func TestValueBoolean(t *testing.T) {
 
 func TestValueConstants(t *testing.T) {
 	t.Parallel()
-	iso, _ := v8go.NewIsolate()
+	iso := v8go.NewIsolate()
 	defer iso.Dispose()
 	ctx, _ := v8go.NewContext(iso)
 	defer ctx.Close()
@@ -378,7 +378,7 @@ func TestValueUint32(t *testing.T) {
 
 func TestValueBigInt(t *testing.T) {
 	t.Parallel()
-	iso, _ := v8go.NewIsolate()
+	iso := v8go.NewIsolate()
 	defer iso.Dispose()
 
 	x, _ := new(big.Int).SetString("36893488147419099136", 10) // larger than a single word size (64bit)
@@ -475,7 +475,7 @@ func TestValueFunction(t *testing.T) {
 
 func TestValueSameValue(t *testing.T) {
 	t.Parallel()
-	iso, _ := v8go.NewIsolate()
+	iso := v8go.NewIsolate()
 	defer iso.Dispose()
 	ctx, _ := v8go.NewContext(iso)
 	defer ctx.Close()
@@ -496,7 +496,7 @@ func TestValueSameValue(t *testing.T) {
 
 func TestValueIsXXX(t *testing.T) {
 	t.Parallel()
-	iso, _ := v8go.NewIsolate()
+	iso := v8go.NewIsolate()
 	defer iso.Dispose()
 	tests := [...]struct {
 		source string
@@ -612,7 +612,7 @@ func TestValueIsXXX(t *testing.T) {
 
 func TestValueMarshalJSON(t *testing.T) {
 	t.Parallel()
-	iso, _ := v8go.NewIsolate()
+	iso := v8go.NewIsolate()
 	defer iso.Dispose()
 
 	tests := [...]struct {


### PR DESCRIPTION
## Problem

Neither [v8::Isolate::New](https://v8.github.io/api/head/classv8_1_1Isolate.html#ab6accf94a5a897fcc1220ab2c049e502) or [v8::Context::New](https://v8.github.io/api/head/classv8_1_1Context.html#aa06c74ca4f5d1aa63449b814825300eb) have a possible error in their return type, but v8go does for NewIsolate and NewContext even though they never return an error. 
 NewIsolate and NewContext have a `// TODO: [RC] catch any C++ exceptions and return as error` comment, yet the [v8go's API Design doc](https://github.com/rogchap/v8go/blob/1c2cf245a0018ee39186e4c193a3fb427069e351/deps/include/APIDesign.md#ecmascript-like-capabilities) now acknowledges that

> V8's C++ code doesn't use C++ exceptions.

This is a [part of the Google's C++ Style Guide](https://google.github.io/styleguide/cppguide.html#Exceptions) that [V8 follows](https://v8.dev/docs/contribute#submit-your-code)

Having functions with an error in their return type that never return an error lead to errors being ignored (as recommended in the README and done in most of the tests) or dead code paths checking for these errors.