### PR TITLE
Recommend importing as v8 instead of the default of v8go

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,13 +14,13 @@
 ## Usage
 
 ```go
-import "rogchap.com/v8go"
+import v8 "rogchap.com/v8go"
 ```
 
 ### Running a script
 
 ```go
-ctx := v8go.NewContext() // creates a new V8 context with a new Isolate aka VM
+ctx := v8.NewContext() // creates a new V8 context with a new Isolate aka VM
 ctx.RunScript("const add = (a, b) => a + b", "math.js") // executes a script on the global context
 ctx.RunScript("const result = add(3, 4)", "main.js") // any functions previously added to the context can be called
 val, _ := ctx.RunScript("result", "value.js") // return a value in JavaScript back to Go
@@ -30,11 +30,11 @@ fmt.Printf("addition result: %s", val)
 ### One VM, many contexts
 
 ```go
-iso := v8go.NewIsolate() // creates a new JavaScript VM
-ctx1 := v8go.NewContext(iso) // new context within the VM
+iso := v8.NewIsolate() // creates a new JavaScript VM
+ctx1 := v8.NewContext(iso) // new context within the VM
 ctx1.RunScript("const multiply = (a, b) => a * b", "math.js")
 
-ctx2 := v8go.NewContext(iso) // another context on the same VM
+ctx2 := v8.NewContext(iso) // another context on the same VM
 if _, err := ctx2.RunScript("multiply(3, 4)", "main.js"); err != nil {
   // this will error as multiply is not defined in this context
 }
@@ -43,22 +43,22 @@ if _, err := ctx2.RunScript("multiply(3, 4)", "main.js"); err != nil {
 ### JavaScript function with Go callback
 
 ```go
-iso := v8go.NewIsolate() // create a new VM
+iso := v8.NewIsolate() // create a new VM
 // a template that represents a JS function
-printfn := v8go.NewFunctionTemplate(iso, func(info *v8go.FunctionCallbackInfo) *v8go.Value {
+printfn := v8.NewFunctionTemplate(iso, func(info *v8.FunctionCallbackInfo) *v8.Value {
     fmt.Printf("%v", info.Args()) // when the JS function is called this Go callback will execute
     return nil // you can return a value back to the JS caller if required
 })
-global := v8go.NewObjectTemplate(iso) // a template that represents a JS Object
+global := v8.NewObjectTemplate(iso) // a template that represents a JS Object
 global.Set("print", printfn) // sets the "print" property of the Object to our function
-ctx := v8go.NewContext(iso, global) // new Context with the global Object set to our object template
+ctx := v8.NewContext(iso, global) // new Context with the global Object set to our object template
 ctx.RunScript("print('foo')", "print.js") // will execute the Go callback with a single argunent 'foo'
 ```
 
 ### Update a JavaScript object from Go
 
 ```go
-ctx := v8go.NewContext() // new context with a default VM
+ctx := v8.NewContext() // new context with a default VM
 obj := ctx.Global() // get the global object from the context
 obj.Set("version", "v1.0.0") // set the property "version" on the object
 val, _ := ctx.RunScript("version", "version.js") // global object will have the property set within the JS VM
@@ -74,7 +74,7 @@ if obj.Has("version") { // check if a property exists on the object
 ```go
 val, err := ctx.RunScript(src, filename)
 if err != nil {
-  e := err.(*v8go.JSError) // JavaScript errors will be returned as the JSError struct
+  e := err.(*v8.JSError) // JavaScript errors will be returned as the JSError struct
   fmt.Println(e.Message) // the message of the exception thrown
   fmt.Println(e.Location) // the filename, line number and the column where the error occured
   fmt.Println(e.StackTrace) // the full stack trace of the error, if available
@@ -87,7 +87,7 @@ if err != nil {
 ### Terminate long running scripts
 
 ```go
-vals := make(chan *v8go.Value, 1)
+vals := make(chan *v8.Value, 1)
 errs := make(chan error, 1)
 
 go func() {

--- a/context_test.go
+++ b/context_test.go
@@ -9,12 +9,12 @@ import (
 	"fmt"
 	"testing"
 
-	"rogchap.com/v8go"
+	v8 "rogchap.com/v8go"
 )
 
 func TestContextExec(t *testing.T) {
 	t.Parallel()
-	ctx := v8go.NewContext(nil)
+	ctx := v8.NewContext(nil)
 	defer ctx.Isolate().Dispose()
 	defer ctx.Close()
 
@@ -31,7 +31,7 @@ func TestContextExec(t *testing.T) {
 	}
 
 	iso := ctx.Isolate()
-	ctx2 := v8go.NewContext(iso)
+	ctx2 := v8.NewContext(iso)
 	_, err = ctx2.RunScript(`add`, "ctx2.js")
 	if err == nil {
 		t.Error("error expected but was <nil>")
@@ -51,7 +51,7 @@ func TestJSExceptions(t *testing.T) {
 		{"ReferenceError", "add()", "add.js", "ReferenceError: add is not defined"},
 	}
 
-	ctx := v8go.NewContext(nil)
+	ctx := v8.NewContext(nil)
 	defer ctx.Isolate().Dispose()
 	defer ctx.Close()
 
@@ -73,19 +73,19 @@ func TestJSExceptions(t *testing.T) {
 func TestContextRegistry(t *testing.T) {
 	t.Parallel()
 
-	ctx := v8go.NewContext()
+	ctx := v8.NewContext()
 	defer ctx.Isolate().Dispose()
 	defer ctx.Close()
 
 	ctxref := ctx.Ref()
 
-	c1 := v8go.GetContext(ctxref)
+	c1 := v8.GetContext(ctxref)
 	if c1 != nil {
 		t.Error("expected context to be <nil>")
 	}
 
 	ctx.Register()
-	c2 := v8go.GetContext(ctxref)
+	c2 := v8.GetContext(ctxref)
 	if c2 == nil {
 		t.Error("expected context, but got <nil>")
 	}
@@ -94,7 +94,7 @@ func TestContextRegistry(t *testing.T) {
 	}
 	ctx.Deregister()
 
-	c3 := v8go.GetContext(ctxref)
+	c3 := v8.GetContext(ctxref)
 	if c3 != nil {
 		t.Error("expected context to be <nil>")
 	}
@@ -103,11 +103,11 @@ func TestContextRegistry(t *testing.T) {
 func TestMemoryLeak(t *testing.T) {
 	t.Parallel()
 
-	iso := v8go.NewIsolate()
+	iso := v8.NewIsolate()
 	defer iso.Dispose()
 
 	for i := 0; i < 6000; i++ {
-		ctx := v8go.NewContext(iso)
+		ctx := v8.NewContext(iso)
 		obj := ctx.Global()
 		_ = obj.String()
 		_, _ = ctx.RunScript("2", "")
@@ -120,10 +120,10 @@ func TestMemoryLeak(t *testing.T) {
 
 func BenchmarkContext(b *testing.B) {
 	b.ReportAllocs()
-	iso := v8go.NewIsolate()
+	iso := v8.NewIsolate()
 	defer iso.Dispose()
 	for n := 0; n < b.N; n++ {
-		ctx := v8go.NewContext(iso)
+		ctx := v8.NewContext(iso)
 		ctx.RunScript(script, "main.js")
 		str, _ := json.Marshal(makeObject())
 		cmd := fmt.Sprintf("process(%s)", str)
@@ -133,7 +133,7 @@ func BenchmarkContext(b *testing.B) {
 }
 
 func ExampleContext() {
-	ctx := v8go.NewContext()
+	ctx := v8.NewContext()
 	defer ctx.Isolate().Dispose()
 	defer ctx.Close()
 	ctx.RunScript("const add = (a, b) => a + b", "math.js")
@@ -145,15 +145,15 @@ func ExampleContext() {
 }
 
 func ExampleContext_isolate() {
-	iso := v8go.NewIsolate()
+	iso := v8.NewIsolate()
 	defer iso.Dispose()
-	ctx1 := v8go.NewContext(iso)
+	ctx1 := v8.NewContext(iso)
 	defer ctx1.Close()
 	ctx1.RunScript("const foo = 'bar'", "context_one.js")
 	val, _ := ctx1.RunScript("foo", "foo.js")
 	fmt.Println(val)
 
-	ctx2 := v8go.NewContext(iso)
+	ctx2 := v8.NewContext(iso)
 	defer ctx2.Close()
 	_, err := ctx2.RunScript("foo", "context_two.js")
 	fmt.Println(err)
@@ -163,11 +163,11 @@ func ExampleContext_isolate() {
 }
 
 func ExampleContext_globalTemplate() {
-	iso := v8go.NewIsolate()
+	iso := v8.NewIsolate()
 	defer iso.Dispose()
-	obj := v8go.NewObjectTemplate(iso)
+	obj := v8.NewObjectTemplate(iso)
 	obj.Set("version", "v1.0.0")
-	ctx := v8go.NewContext(iso, obj)
+	ctx := v8.NewContext(iso, obj)
 	defer ctx.Close()
 	val, _ := ctx.RunScript("version", "main.js")
 	fmt.Println(val)

--- a/errors_test.go
+++ b/errors_test.go
@@ -8,7 +8,7 @@ import (
 	"fmt"
 	"testing"
 
-	"rogchap.com/v8go"
+	v8 "rogchap.com/v8go"
 )
 
 func TestErrorFormatting(t *testing.T) {
@@ -21,8 +21,8 @@ func TestErrorFormatting(t *testing.T) {
 		stringVerb      string
 		quoteVerb       string
 	}{
-		{"WithStack", &v8go.JSError{Message: "msg", StackTrace: "stack"}, "msg", "stack", "msg", `"msg"`},
-		{"WithoutStack", &v8go.JSError{Message: "msg"}, "msg", "msg", "msg", `"msg"`},
+		{"WithStack", &v8.JSError{Message: "msg", StackTrace: "stack"}, "msg", "stack", "msg", `"msg"`},
+		{"WithoutStack", &v8.JSError{Message: "msg"}, "msg", "msg", "msg", `"msg"`},
 	}
 
 	for _, tt := range tests {
@@ -47,7 +47,7 @@ func TestErrorFormatting(t *testing.T) {
 
 func TestJSErrorOutput(t *testing.T) {
 	t.Parallel()
-	ctx := v8go.NewContext(nil)
+	ctx := v8.NewContext(nil)
 	defer ctx.Isolate().Dispose()
 	defer ctx.Close()
 
@@ -72,7 +72,7 @@ func TestJSErrorOutput(t *testing.T) {
 		t.Error("expected error but got <nil>")
 		return
 	}
-	e, ok := err.(*v8go.JSError)
+	e, ok := err.(*v8.JSError)
 	if !ok {
 		t.Errorf("expected error of type JSError, got %T", err)
 	}

--- a/function_test.go
+++ b/function_test.go
@@ -7,13 +7,13 @@ package v8go_test
 import (
 	"testing"
 
-	"rogchap.com/v8go"
+	v8 "rogchap.com/v8go"
 )
 
 func TestFunctionCall(t *testing.T) {
 	t.Parallel()
 
-	ctx := v8go.NewContext()
+	ctx := v8.NewContext()
 	defer ctx.Isolate().Dispose()
 	defer ctx.Close()
 
@@ -23,11 +23,11 @@ func TestFunctionCall(t *testing.T) {
 	failIf(t, err)
 	iso := ctx.Isolate()
 
-	arg1, err := v8go.NewValue(iso, int32(1))
+	arg1, err := v8.NewValue(iso, int32(1))
 	failIf(t, err)
 
 	fn, _ := addValue.AsFunction()
-	resultValue, err := fn.Call(v8go.Undefined(iso), arg1, arg1)
+	resultValue, err := fn.Call(v8.Undefined(iso), arg1, arg1)
 	failIf(t, err)
 
 	if resultValue.Int32() != 2 {
@@ -38,27 +38,27 @@ func TestFunctionCall(t *testing.T) {
 func TestFunctionCallToGoFunc(t *testing.T) {
 	t.Parallel()
 
-	iso := v8go.NewIsolate()
+	iso := v8.NewIsolate()
 	defer iso.Dispose()
-	global := v8go.NewObjectTemplate(iso)
+	global := v8.NewObjectTemplate(iso)
 
 	called := false
-	printfn := v8go.NewFunctionTemplate(iso, func(info *v8go.FunctionCallbackInfo) *v8go.Value {
+	printfn := v8.NewFunctionTemplate(iso, func(info *v8.FunctionCallbackInfo) *v8.Value {
 		called = true
 		return nil
 	})
 
-	err := global.Set("print", printfn, v8go.ReadOnly)
+	err := global.Set("print", printfn, v8.ReadOnly)
 	failIf(t, err)
 
-	ctx := v8go.NewContext(iso, global)
+	ctx := v8.NewContext(iso, global)
 	defer ctx.Close()
 
 	val, err := ctx.RunScript(`(a, b) => { print("foo"); }`, "")
 	failIf(t, err)
 	fn, err := val.AsFunction()
 	failIf(t, err)
-	resultValue, err := fn.Call(v8go.Undefined(iso))
+	resultValue, err := fn.Call(v8.Undefined(iso))
 	failIf(t, err)
 
 	if !called {
@@ -72,10 +72,10 @@ func TestFunctionCallToGoFunc(t *testing.T) {
 func TestFunctionCallWithObjectReceiver(t *testing.T) {
 	t.Parallel()
 
-	iso := v8go.NewIsolate()
-	global := v8go.NewObjectTemplate(iso)
+	iso := v8.NewIsolate()
+	global := v8.NewObjectTemplate(iso)
 
-	ctx := v8go.NewContext(iso, global)
+	ctx := v8.NewContext(iso, global)
 	val, err := ctx.RunScript(`class Obj { constructor(input) { this.input = input } print() { return this.input.toString() } }; new Obj("some val")`, "")
 	failIf(t, err)
 	obj, err := val.AsObject()
@@ -95,7 +95,7 @@ func TestFunctionCallWithObjectReceiver(t *testing.T) {
 func TestFunctionCallError(t *testing.T) {
 	t.Parallel()
 
-	ctx := v8go.NewContext()
+	ctx := v8.NewContext()
 	iso := ctx.Isolate()
 	defer iso.Dispose()
 	defer ctx.Close()
@@ -106,12 +106,12 @@ func TestFunctionCallError(t *testing.T) {
 	failIf(t, err)
 
 	fn, _ := addValue.AsFunction()
-	_, err = fn.Call(v8go.Undefined(iso))
+	_, err = fn.Call(v8.Undefined(iso))
 	if err == nil {
 		t.Errorf("expected an error, got none")
 	}
-	got := *(err.(*v8go.JSError))
-	want := v8go.JSError{Message: "error", Location: "script.js:1:21"}
+	got := *(err.(*v8.JSError))
+	want := v8.JSError{Message: "error", Location: "script.js:1:21"}
 	if got != want {
 		t.Errorf("want %+v, got: %+v", want, got)
 	}
@@ -120,7 +120,7 @@ func TestFunctionCallError(t *testing.T) {
 func TestFunctionSourceMapUrl(t *testing.T) {
 	t.Parallel()
 
-	ctx := v8go.NewContext()
+	ctx := v8.NewContext()
 	defer ctx.Isolate().Dispose()
 	defer ctx.Close()
 	_, err := ctx.RunScript("function add(a, b) { return a + b; }; //# sourceMappingURL=main.js.map", "main.js")
@@ -150,7 +150,7 @@ func TestFunctionSourceMapUrl(t *testing.T) {
 func TestFunctionNewInstance(t *testing.T) {
 	t.Parallel()
 
-	ctx := v8go.NewContext()
+	ctx := v8.NewContext()
 	defer ctx.Isolate().Dispose()
 	defer ctx.Close()
 
@@ -160,7 +160,7 @@ func TestFunctionNewInstance(t *testing.T) {
 	failIf(t, err)
 	fn, err := value.AsFunction()
 	failIf(t, err)
-	messageObj, err := v8go.NewValue(iso, "test message")
+	messageObj, err := v8.NewValue(iso, "test message")
 	failIf(t, err)
 	errObj, err := fn.NewInstance(messageObj)
 	failIf(t, err)
@@ -180,7 +180,7 @@ func TestFunctionNewInstance(t *testing.T) {
 func TestFunctionNewInstanceError(t *testing.T) {
 	t.Parallel()
 
-	ctx := v8go.NewContext()
+	ctx := v8.NewContext()
 	defer ctx.Isolate().Dispose()
 	defer ctx.Close()
 
@@ -194,8 +194,8 @@ func TestFunctionNewInstanceError(t *testing.T) {
 	if err == nil {
 		t.Errorf("expected an error, got none")
 	}
-	got := *(err.(*v8go.JSError))
-	want := v8go.JSError{Message: "error", Location: "script.js:1:21"}
+	got := *(err.(*v8.JSError))
+	want := v8.JSError{Message: "error", Location: "script.js:1:21"}
 	if got != want {
 		t.Errorf("want %+v, got: %+v", want, got)
 	}

--- a/isolate_test.go
+++ b/isolate_test.go
@@ -13,12 +13,12 @@ import (
 	"testing"
 	"time"
 
-	"rogchap.com/v8go"
+	v8 "rogchap.com/v8go"
 )
 
 func TestIsolateTermination(t *testing.T) {
 	t.Parallel()
-	iso := v8go.NewIsolate()
+	iso := v8.NewIsolate()
 	defer iso.Dispose()
 
 	if iso.IsExecutionTerminating() {
@@ -26,18 +26,18 @@ func TestIsolateTermination(t *testing.T) {
 	}
 
 	var terminating bool
-	fooFn := v8go.NewFunctionTemplate(iso, func(info *v8go.FunctionCallbackInfo) *v8go.Value {
+	fooFn := v8.NewFunctionTemplate(iso, func(info *v8.FunctionCallbackInfo) *v8.Value {
 		loop, _ := info.Args()[0].AsFunction()
-		loop.Call(v8go.Undefined(iso))
+		loop.Call(v8.Undefined(iso))
 
 		terminating = iso.IsExecutionTerminating()
 		return nil
 	})
 
-	global := v8go.NewObjectTemplate(iso)
+	global := v8.NewObjectTemplate(iso)
 	global.Set("foo", fooFn)
 
-	ctx := v8go.NewContext(iso, global)
+	ctx := v8.NewContext(iso, global)
 	defer ctx.Close()
 
 	go func() {
@@ -59,11 +59,11 @@ func TestIsolateTermination(t *testing.T) {
 
 func TestGetHeapStatistics(t *testing.T) {
 	t.Parallel()
-	iso := v8go.NewIsolate()
+	iso := v8.NewIsolate()
 	defer iso.Dispose()
-	ctx1 := v8go.NewContext(iso)
+	ctx1 := v8.NewContext(iso)
 	defer ctx1.Close()
-	ctx2 := v8go.NewContext(iso)
+	ctx2 := v8.NewContext(iso)
 	defer ctx2.Close()
 
 	hs := iso.GetHeapStatistics()
@@ -80,9 +80,9 @@ func TestGetHeapStatistics(t *testing.T) {
 func TestCallbackRegistry(t *testing.T) {
 	t.Parallel()
 
-	iso := v8go.NewIsolate()
+	iso := v8.NewIsolate()
 	defer iso.Dispose()
-	cb := func(*v8go.FunctionCallbackInfo) *v8go.Value { return nil }
+	cb := func(*v8.FunctionCallbackInfo) *v8.Value { return nil }
 
 	cb0 := iso.GetCallback(0)
 	if cb0 != nil {
@@ -101,7 +101,7 @@ func TestCallbackRegistry(t *testing.T) {
 func TestIsolateDispose(t *testing.T) {
 	t.Parallel()
 
-	iso := v8go.NewIsolate()
+	iso := v8.NewIsolate()
 	if iso.GetHeapStatistics().TotalHeapSize == 0 {
 		t.Error("Isolate incorrectly allocated")
 	}
@@ -120,13 +120,13 @@ func TestIsolateDispose(t *testing.T) {
 func TestIsolateGarbageCollection(t *testing.T) {
 	t.Parallel()
 
-	iso := v8go.NewIsolate()
-	val, _ := v8go.NewValue(iso, "some string")
+	iso := v8.NewIsolate()
+	val, _ := v8.NewValue(iso, "some string")
 	fmt.Println(val.String())
 
-	tmpl := v8go.NewObjectTemplate(iso)
+	tmpl := v8.NewObjectTemplate(iso)
 	tmpl.Set("foo", "bar")
-	v8go.NewContext(iso, tmpl)
+	v8.NewContext(iso, tmpl)
 
 	iso.Dispose()
 
@@ -138,7 +138,7 @@ func TestIsolateGarbageCollection(t *testing.T) {
 func BenchmarkIsolateInitialization(b *testing.B) {
 	b.ReportAllocs()
 	for n := 0; n < b.N; n++ {
-		vm := v8go.NewIsolate()
+		vm := v8.NewIsolate()
 		vm.Close() // force disposal of the VM
 	}
 }
@@ -146,8 +146,8 @@ func BenchmarkIsolateInitialization(b *testing.B) {
 func BenchmarkIsolateInitAndRun(b *testing.B) {
 	b.ReportAllocs()
 	for n := 0; n < b.N; n++ {
-		vm := v8go.NewIsolate()
-		ctx := v8go.NewContext(vm)
+		vm := v8.NewIsolate()
+		ctx := v8.NewContext(vm)
 		ctx.RunScript(script, "main.js")
 		str, _ := json.Marshal(makeObject())
 		cmd := fmt.Sprintf("process(%s)", str)

--- a/json_test.go
+++ b/json_test.go
@@ -1,4 +1,4 @@
-// Copyright 2021 Roger Chapman and the v8go contributors. All rights reserved.
+// Copyright 2021 Roger Chapman and the v8 contributors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
@@ -8,25 +8,25 @@ import (
 	"fmt"
 	"testing"
 
-	"rogchap.com/v8go"
+	v8 "rogchap.com/v8go"
 )
 
 func TestJSONParse(t *testing.T) {
 	t.Parallel()
 
-	if _, err := v8go.JSONParse(nil, "{}"); err == nil {
+	if _, err := v8.JSONParse(nil, "{}"); err == nil {
 		t.Error("expected error but got <nil>")
 	}
-	ctx := v8go.NewContext()
+	ctx := v8.NewContext()
 	defer ctx.Isolate().Dispose()
 	defer ctx.Close()
-	_, err := v8go.JSONParse(ctx, "{")
+	_, err := v8.JSONParse(ctx, "{")
 	if err == nil {
 		t.Error("expected error but got <nil>")
 		return
 	}
 
-	if _, ok := err.(*v8go.JSError); !ok {
+	if _, ok := err.(*v8.JSError); !ok {
 		t.Errorf("expected error to be of type JSError, got: %T", err)
 	}
 }
@@ -34,33 +34,33 @@ func TestJSONParse(t *testing.T) {
 func TestJSONStringify(t *testing.T) {
 	t.Parallel()
 
-	ctx := v8go.NewContext()
+	ctx := v8.NewContext()
 	defer ctx.Isolate().Dispose()
 	defer ctx.Close()
-	if _, err := v8go.JSONStringify(ctx, nil); err == nil {
+	if _, err := v8.JSONStringify(ctx, nil); err == nil {
 		t.Error("expected error but got <nil>")
 	}
 }
 
 func ExampleJSONParse() {
-	ctx := v8go.NewContext()
+	ctx := v8.NewContext()
 	defer ctx.Isolate().Dispose()
 	defer ctx.Close()
-	val, _ := v8go.JSONParse(ctx, `{"foo": "bar"}`)
+	val, _ := v8.JSONParse(ctx, `{"foo": "bar"}`)
 	fmt.Println(val)
 	// Output:
 	// [object Object]
 }
 
 func ExampleJSONStringify() {
-	ctx := v8go.NewContext()
+	ctx := v8.NewContext()
 	defer ctx.Isolate().Dispose()
 	defer ctx.Close()
-	val, _ := v8go.JSONParse(ctx, `{
+	val, _ := v8.JSONParse(ctx, `{
 		"a": 1,
 		"b": "foo"
 	}`)
-	jsonStr, _ := v8go.JSONStringify(ctx, val)
+	jsonStr, _ := v8.JSONStringify(ctx, val)
 	fmt.Println(jsonStr)
 	// Output:
 	// {"a":1,"b":"foo"}

--- a/object_template_test.go
+++ b/object_template_test.go
@@ -8,14 +8,14 @@ import (
 	"math/big"
 	"testing"
 
-	"rogchap.com/v8go"
+	v8 "rogchap.com/v8go"
 )
 
 func TestObjectTemplate(t *testing.T) {
 	t.Parallel()
-	iso := v8go.NewIsolate()
+	iso := v8.NewIsolate()
 	defer iso.Dispose()
-	obj := v8go.NewObjectTemplate(iso)
+	obj := v8.NewObjectTemplate(iso)
 
 	setError := func(t *testing.T, err error) {
 		if err != nil {
@@ -23,8 +23,8 @@ func TestObjectTemplate(t *testing.T) {
 		}
 	}
 
-	val, _ := v8go.NewValue(iso, "bar")
-	objVal := v8go.NewObjectTemplate(iso)
+	val, _ := v8.NewValue(iso, "bar")
+	objVal := v8.NewObjectTemplate(iso)
 	bigbigint, _ := new(big.Int).SetString("36893488147419099136", 10) // larger than a single word size (64bit)
 	bigbignegint, _ := new(big.Int).SetString("-36893488147419099136", 10)
 
@@ -63,26 +63,26 @@ func TestObjectTemplate_panic_on_nil_isolate(t *testing.T) {
 			t.Error("expected panic")
 		}
 	}()
-	v8go.NewObjectTemplate(nil)
+	v8.NewObjectTemplate(nil)
 }
 
 func TestGlobalObjectTemplate(t *testing.T) {
 	t.Parallel()
-	iso := v8go.NewIsolate()
+	iso := v8.NewIsolate()
 	defer iso.Dispose()
 	tests := [...]struct {
-		global   func() *v8go.ObjectTemplate
+		global   func() *v8.ObjectTemplate
 		source   string
-		validate func(t *testing.T, val *v8go.Value)
+		validate func(t *testing.T, val *v8.Value)
 	}{
 		{
-			func() *v8go.ObjectTemplate {
-				gbl := v8go.NewObjectTemplate(iso)
+			func() *v8.ObjectTemplate {
+				gbl := v8.NewObjectTemplate(iso)
 				gbl.Set("foo", "bar")
 				return gbl
 			},
 			"foo",
-			func(t *testing.T, val *v8go.Value) {
+			func(t *testing.T, val *v8.Value) {
 				if !val.IsString() {
 					t.Errorf("expect value %q to be of type String", val)
 					return
@@ -93,15 +93,15 @@ func TestGlobalObjectTemplate(t *testing.T) {
 			},
 		},
 		{
-			func() *v8go.ObjectTemplate {
-				foo := v8go.NewObjectTemplate(iso)
+			func() *v8.ObjectTemplate {
+				foo := v8.NewObjectTemplate(iso)
 				foo.Set("bar", "baz")
-				gbl := v8go.NewObjectTemplate(iso)
+				gbl := v8.NewObjectTemplate(iso)
 				gbl.Set("foo", foo)
 				return gbl
 			},
 			"foo.bar",
-			func(t *testing.T, val *v8go.Value) {
+			func(t *testing.T, val *v8.Value) {
 				if val.String() != "baz" {
 					t.Errorf("unexpected value: %v", val)
 				}
@@ -112,7 +112,7 @@ func TestGlobalObjectTemplate(t *testing.T) {
 	for _, tt := range tests {
 		tt := tt
 		t.Run(tt.source, func(t *testing.T) {
-			ctx := v8go.NewContext(iso, tt.global())
+			ctx := v8.NewContext(iso, tt.global())
 			val, err := ctx.RunScript(tt.source, "test.js")
 			if err != nil {
 				t.Fatalf("unexpected error runing script: %v", err)
@@ -125,15 +125,15 @@ func TestGlobalObjectTemplate(t *testing.T) {
 
 func TestObjectTemplateNewInstance(t *testing.T) {
 	t.Parallel()
-	iso := v8go.NewIsolate()
+	iso := v8.NewIsolate()
 	defer iso.Dispose()
-	tmpl := v8go.NewObjectTemplate(iso)
+	tmpl := v8.NewObjectTemplate(iso)
 	if _, err := tmpl.NewInstance(nil); err == nil {
 		t.Error("expected error but got <nil>")
 	}
 
 	tmpl.Set("foo", "bar")
-	ctx := v8go.NewContext(iso)
+	ctx := v8.NewContext(iso)
 	defer ctx.Close()
 	obj, _ := tmpl.NewInstance(ctx)
 	if foo, _ := obj.Get("foo"); foo.String() != "bar" {

--- a/object_test.go
+++ b/object_test.go
@@ -8,13 +8,13 @@ import (
 	"fmt"
 	"testing"
 
-	"rogchap.com/v8go"
+	v8 "rogchap.com/v8go"
 )
 
 func TestObjectMethodCall(t *testing.T) {
 	t.Parallel()
 
-	ctx := v8go.NewContext()
+	ctx := v8.NewContext()
 	iso := ctx.Isolate()
 	val, _ := ctx.RunScript(`class Obj { constructor(input) { this.input = input, this.prop = "" } print() { return this.input.toString() } }; new Obj("some val")`, "")
 	obj, _ := val.AsObject()
@@ -31,7 +31,7 @@ func TestObjectMethodCall(t *testing.T) {
 	val, err = ctx.RunScript(`class Obj2 { print(str) { return str.toString() }; get fails() { throw "error" } }; new Obj2()`, "")
 	failIf(t, err)
 	obj, _ = val.AsObject()
-	arg, _ := v8go.NewValue(iso, "arg")
+	arg, _ := v8.NewValue(iso, "arg")
 	val, err = obj.MethodCall("print", arg)
 	failIf(t, err)
 	if val.String() != "arg" {
@@ -46,7 +46,7 @@ func TestObjectMethodCall(t *testing.T) {
 func TestObjectSet(t *testing.T) {
 	t.Parallel()
 
-	ctx := v8go.NewContext()
+	ctx := v8.NewContext()
 	defer ctx.Isolate().Dispose()
 	defer ctx.Close()
 	val, _ := ctx.RunScript("const foo = {}; foo", "")
@@ -71,7 +71,7 @@ func TestObjectSet(t *testing.T) {
 func TestObjectGet(t *testing.T) {
 	t.Parallel()
 
-	ctx := v8go.NewContext()
+	ctx := v8.NewContext()
 	defer ctx.Isolate().Dispose()
 	defer ctx.Close()
 	val, _ := ctx.RunScript("const foo = { bar: 'baz'}; foo", "")
@@ -94,7 +94,7 @@ func TestObjectGet(t *testing.T) {
 func TestObjectHas(t *testing.T) {
 	t.Parallel()
 
-	ctx := v8go.NewContext()
+	ctx := v8.NewContext()
 	defer ctx.Isolate().Dispose()
 	defer ctx.Close()
 	val, _ := ctx.RunScript("const foo = {a: 1, '2': 2}; foo", "")
@@ -116,7 +116,7 @@ func TestObjectHas(t *testing.T) {
 func TestObjectDelete(t *testing.T) {
 	t.Parallel()
 
-	ctx := v8go.NewContext()
+	ctx := v8.NewContext()
 	defer ctx.Isolate().Dispose()
 	defer ctx.Close()
 	val, _ := ctx.RunScript("const foo = { bar: 'baz', '2': 2}; foo", "")
@@ -137,14 +137,14 @@ func TestObjectDelete(t *testing.T) {
 }
 
 func ExampleObject_global() {
-	iso := v8go.NewIsolate()
+	iso := v8.NewIsolate()
 	defer iso.Dispose()
-	ctx := v8go.NewContext(iso)
+	ctx := v8.NewContext(iso)
 	defer ctx.Close()
 	global := ctx.Global()
 
-	console := v8go.NewObjectTemplate(iso)
-	logfn := v8go.NewFunctionTemplate(iso, func(info *v8go.FunctionCallbackInfo) *v8go.Value {
+	console := v8.NewObjectTemplate(iso)
+	logfn := v8.NewFunctionTemplate(iso, func(info *v8.FunctionCallbackInfo) *v8.Value {
 		fmt.Println(info.Args()[0])
 		return nil
 	})

--- a/promise_test.go
+++ b/promise_test.go
@@ -7,44 +7,44 @@ package v8go_test
 import (
 	"testing"
 
-	"rogchap.com/v8go"
+	v8 "rogchap.com/v8go"
 )
 
 func TestPromiseFulfilled(t *testing.T) {
 	t.Parallel()
 
-	iso := v8go.NewIsolate()
+	iso := v8.NewIsolate()
 	defer iso.Dispose()
-	ctx := v8go.NewContext(iso)
+	ctx := v8.NewContext(iso)
 	defer ctx.Close()
 
-	if _, err := v8go.NewPromiseResolver(nil); err == nil {
+	if _, err := v8.NewPromiseResolver(nil); err == nil {
 		t.Error("expected error with <nil> Context")
 	}
 
-	res1, _ := v8go.NewPromiseResolver(ctx)
+	res1, _ := v8.NewPromiseResolver(ctx)
 	prom1 := res1.GetPromise()
-	if s := prom1.State(); s != v8go.Pending {
+	if s := prom1.State(); s != v8.Pending {
 		t.Errorf("unexpected state for Promise, want Pending (0) got: %v", s)
 	}
 
-	var thenInfo *v8go.FunctionCallbackInfo
-	prom1thenVal := prom1.Then(func(info *v8go.FunctionCallbackInfo) *v8go.Value {
+	var thenInfo *v8.FunctionCallbackInfo
+	prom1thenVal := prom1.Then(func(info *v8.FunctionCallbackInfo) *v8.Value {
 		thenInfo = info
 		return nil
 	})
 	prom1then, _ := prom1thenVal.AsPromise()
-	if prom1then.State() != v8go.Pending {
+	if prom1then.State() != v8.Pending {
 		t.Errorf("unexpected state for dependent Promise, want Pending got: %v", prom1then.State())
 	}
 	if thenInfo != nil {
 		t.Error("unexpected call of Then prior to resolving the promise")
 	}
 
-	val1, _ := v8go.NewValue(iso, "foo")
+	val1, _ := v8.NewValue(iso, "foo")
 	res1.Resolve(val1)
 
-	if s := prom1.State(); s != v8go.Fulfilled {
+	if s := prom1.State(); s != v8.Fulfilled {
 		t.Fatalf("unexpected state for Promise, want Fulfilled (1) got: %v", s)
 	}
 
@@ -63,33 +63,33 @@ func TestPromiseFulfilled(t *testing.T) {
 func TestPromiseRejected(t *testing.T) {
 	t.Parallel()
 
-	iso := v8go.NewIsolate()
+	iso := v8.NewIsolate()
 	defer iso.Dispose()
-	ctx := v8go.NewContext(iso)
+	ctx := v8.NewContext(iso)
 	defer ctx.Close()
 
-	res2, _ := v8go.NewPromiseResolver(ctx)
-	val2, _ := v8go.NewValue(iso, "Bad Foo")
+	res2, _ := v8.NewPromiseResolver(ctx)
+	val2, _ := v8.NewValue(iso, "Bad Foo")
 	res2.Reject(val2)
 
 	prom2 := res2.GetPromise()
-	if s := prom2.State(); s != v8go.Rejected {
+	if s := prom2.State(); s != v8.Rejected {
 		t.Fatalf("unexpected state for Promise, want Rejected (2) got: %v", s)
 	}
 
-	var thenInfo *v8go.FunctionCallbackInfo
+	var thenInfo *v8.FunctionCallbackInfo
 	var then2Fulfilled, then2Rejected bool
 	prom2.
-		Catch(func(info *v8go.FunctionCallbackInfo) *v8go.Value {
+		Catch(func(info *v8.FunctionCallbackInfo) *v8.Value {
 			thenInfo = info
 			return nil
 		}).
 		Then(
-			func(_ *v8go.FunctionCallbackInfo) *v8go.Value {
+			func(_ *v8.FunctionCallbackInfo) *v8.Value {
 				then2Fulfilled = true
 				return nil
 			},
-			func(_ *v8go.FunctionCallbackInfo) *v8go.Value {
+			func(_ *v8.FunctionCallbackInfo) *v8.Value {
 				then2Rejected = true
 				return nil
 			},
@@ -113,12 +113,12 @@ func TestPromiseRejected(t *testing.T) {
 func TestPromiseThenPanic(t *testing.T) {
 	t.Parallel()
 
-	iso := v8go.NewIsolate()
+	iso := v8.NewIsolate()
 	defer iso.Dispose()
-	ctx := v8go.NewContext(iso)
+	ctx := v8.NewContext(iso)
 	defer ctx.Close()
 
-	res, _ := v8go.NewPromiseResolver(ctx)
+	res, _ := v8.NewPromiseResolver(ctx)
 	prom := res.GetPromise()
 
 	t.Run("no callbacks", func(t *testing.T) {
@@ -128,7 +128,7 @@ func TestPromiseThenPanic(t *testing.T) {
 	})
 	t.Run("3 callbacks", func(t *testing.T) {
 		defer func() { recover() }()
-		fn := func(_ *v8go.FunctionCallbackInfo) *v8go.Value { return nil }
+		fn := func(_ *v8.FunctionCallbackInfo) *v8.Value { return nil }
 		prom.Then(fn, fn, fn)
 		t.Errorf("expected a panic")
 	})

--- a/v8go_test.go
+++ b/v8go_test.go
@@ -8,13 +8,13 @@ import (
 	"regexp"
 	"testing"
 
-	"rogchap.com/v8go"
+	v8 "rogchap.com/v8go"
 )
 
 func TestVersion(t *testing.T) {
 	t.Parallel()
 	rgx := regexp.MustCompile(`^\d+\.\d+\.\d+\.\d+-v8go$`)
-	v := v8go.Version()
+	v := v8.Version()
 	if !rgx.MatchString(v) {
 		t.Errorf("version string is in the incorrect format: %s", v)
 	}
@@ -22,17 +22,17 @@ func TestVersion(t *testing.T) {
 
 func TestSetFlag(t *testing.T) {
 	t.Parallel()
-	ctx := v8go.NewContext()
+	ctx := v8.NewContext()
 	defer ctx.Isolate().Dispose()
 	defer ctx.Close()
 	if _, err := ctx.RunScript("a = 1", "default.js"); err != nil {
 		t.Errorf("expected <nil> error, but got: %v", err)
 	}
-	v8go.SetFlags("--use_strict")
+	v8.SetFlags("--use_strict")
 	if _, err := ctx.RunScript("b = 1", "use_strict.js"); err == nil {
 		t.Error("expected error but got <nil>")
 	}
-	v8go.SetFlags("--nouse_strict")
+	v8.SetFlags("--nouse_strict")
 	if _, err := ctx.RunScript("c = 1", "nouse_strict.js"); err != nil {
 		t.Errorf("expected <nil> error, but got: %v", err)
 	}

--- a/value_test.go
+++ b/value_test.go
@@ -13,20 +13,20 @@ import (
 	"runtime"
 	"testing"
 
-	"rogchap.com/v8go"
+	v8 "rogchap.com/v8go"
 )
 
 func TestValueNewBaseCases(t *testing.T) {
 	t.Parallel()
-	if _, err := v8go.NewValue(nil, ""); err == nil {
+	if _, err := v8.NewValue(nil, ""); err == nil {
 		t.Error("expected error, but got <nil>")
 	}
-	iso := v8go.NewIsolate()
+	iso := v8.NewIsolate()
 	defer iso.Dispose()
-	if _, err := v8go.NewValue(iso, nil); err == nil {
+	if _, err := v8.NewValue(iso, nil); err == nil {
 		t.Error("expected error, but got <nil>")
 	}
-	if _, err := v8go.NewValue(iso, struct{}{}); err == nil {
+	if _, err := v8.NewValue(iso, struct{}{}); err == nil {
 		t.Error("expected error, but got <nil>")
 	}
 
@@ -34,7 +34,7 @@ func TestValueNewBaseCases(t *testing.T) {
 
 func TestValueFormatting(t *testing.T) {
 	t.Parallel()
-	ctx := v8go.NewContext(nil)
+	ctx := v8.NewContext(nil)
 	defer ctx.Isolate().Dispose()
 	defer ctx.Close()
 
@@ -70,7 +70,7 @@ func TestValueFormatting(t *testing.T) {
 
 func TestValueString(t *testing.T) {
 	t.Parallel()
-	ctx := v8go.NewContext(nil)
+	ctx := v8.NewContext(nil)
 	defer ctx.Isolate().Dispose()
 	defer ctx.Close()
 
@@ -99,7 +99,7 @@ func TestValueString(t *testing.T) {
 
 func TestValueDetailString(t *testing.T) {
 	t.Parallel()
-	ctx := v8go.NewContext(nil)
+	ctx := v8.NewContext(nil)
 	defer ctx.Isolate().Dispose()
 	defer ctx.Close()
 
@@ -128,7 +128,7 @@ func TestValueDetailString(t *testing.T) {
 
 func TestValueBoolean(t *testing.T) {
 	t.Parallel()
-	ctx := v8go.NewContext(nil)
+	ctx := v8.NewContext(nil)
 	defer ctx.Isolate().Dispose()
 	defer ctx.Close()
 
@@ -162,19 +162,19 @@ func TestValueBoolean(t *testing.T) {
 
 func TestValueConstants(t *testing.T) {
 	t.Parallel()
-	iso := v8go.NewIsolate()
+	iso := v8.NewIsolate()
 	defer iso.Dispose()
-	ctx := v8go.NewContext(iso)
+	ctx := v8.NewContext(iso)
 	defer ctx.Close()
 
 	tests := [...]struct {
 		source string
-		value  *v8go.Value
+		value  *v8.Value
 		same   bool
 	}{
-		{"undefined", v8go.Undefined(iso), true},
-		{"null", v8go.Null(iso), true},
-		{"undefined", v8go.Null(iso), false},
+		{"undefined", v8.Undefined(iso), true},
+		{"null", v8.Null(iso), true},
+		{"undefined", v8.Null(iso), false},
 	}
 
 	for _, tt := range tests {
@@ -192,7 +192,7 @@ func TestValueConstants(t *testing.T) {
 
 func TestValueArrayIndex(t *testing.T) {
 	t.Parallel()
-	ctx := v8go.NewContext(nil)
+	ctx := v8.NewContext(nil)
 	defer ctx.Isolate().Dispose()
 	defer ctx.Close()
 
@@ -230,7 +230,7 @@ func TestValueArrayIndex(t *testing.T) {
 
 func TestValueInt32(t *testing.T) {
 	t.Parallel()
-	ctx := v8go.NewContext(nil)
+	ctx := v8.NewContext(nil)
 	defer ctx.Isolate().Dispose()
 	defer ctx.Close()
 
@@ -269,7 +269,7 @@ func TestValueInt32(t *testing.T) {
 
 func TestValueInteger(t *testing.T) {
 	t.Parallel()
-	ctx := v8go.NewContext(nil)
+	ctx := v8.NewContext(nil)
 	defer ctx.Isolate().Dispose()
 	defer ctx.Close()
 
@@ -308,7 +308,7 @@ func TestValueInteger(t *testing.T) {
 
 func TestValueNumber(t *testing.T) {
 	t.Parallel()
-	ctx := v8go.NewContext(nil)
+	ctx := v8.NewContext(nil)
 	defer ctx.Isolate().Dispose()
 	defer ctx.Close()
 
@@ -352,7 +352,7 @@ func TestValueNumber(t *testing.T) {
 
 func TestValueUint32(t *testing.T) {
 	t.Parallel()
-	ctx := v8go.NewContext(nil)
+	ctx := v8.NewContext(nil)
 	defer ctx.Isolate().Dispose()
 	defer ctx.Close()
 
@@ -378,7 +378,7 @@ func TestValueUint32(t *testing.T) {
 
 func TestValueBigInt(t *testing.T) {
 	t.Parallel()
-	iso := v8go.NewIsolate()
+	iso := v8.NewIsolate()
 	defer iso.Dispose()
 
 	x, _ := new(big.Int).SetString("36893488147419099136", 10) // larger than a single word size (64bit)
@@ -399,7 +399,7 @@ func TestValueBigInt(t *testing.T) {
 	for _, tt := range tests {
 		tt := tt
 		t.Run(tt.source, func(t *testing.T) {
-			ctx := v8go.NewContext(iso)
+			ctx := v8.NewContext(iso)
 			defer ctx.Close()
 
 			val, _ := ctx.RunScript(tt.source, "test.js")
@@ -422,7 +422,7 @@ func TestValueBigInt(t *testing.T) {
 func TestValueObject(t *testing.T) {
 	t.Parallel()
 
-	ctx := v8go.NewContext()
+	ctx := v8.NewContext()
 	defer ctx.Isolate().Dispose()
 	defer ctx.Close()
 
@@ -438,7 +438,7 @@ func TestValueObject(t *testing.T) {
 func TestValuePromise(t *testing.T) {
 	t.Parallel()
 
-	ctx := v8go.NewContext()
+	ctx := v8.NewContext()
 	defer ctx.Isolate().Dispose()
 	defer ctx.Close()
 
@@ -455,7 +455,7 @@ func TestValuePromise(t *testing.T) {
 func TestValueFunction(t *testing.T) {
 	t.Parallel()
 
-	ctx := v8go.NewContext()
+	ctx := v8.NewContext()
 	defer ctx.Isolate().Dispose()
 	defer ctx.Close()
 
@@ -475,12 +475,12 @@ func TestValueFunction(t *testing.T) {
 
 func TestValueSameValue(t *testing.T) {
 	t.Parallel()
-	iso := v8go.NewIsolate()
+	iso := v8.NewIsolate()
 	defer iso.Dispose()
-	ctx := v8go.NewContext(iso)
+	ctx := v8.NewContext(iso)
 	defer ctx.Close()
 
-	objTempl := v8go.NewObjectTemplate(iso)
+	objTempl := v8.NewObjectTemplate(iso)
 	obj1, err := objTempl.NewInstance(ctx)
 	failIf(t, err)
 	obj2, err := objTempl.NewInstance(ctx)
@@ -496,107 +496,107 @@ func TestValueSameValue(t *testing.T) {
 
 func TestValueIsXXX(t *testing.T) {
 	t.Parallel()
-	iso := v8go.NewIsolate()
+	iso := v8.NewIsolate()
 	defer iso.Dispose()
 	tests := [...]struct {
 		source string
-		assert func(*v8go.Value) bool
+		assert func(*v8.Value) bool
 	}{
-		{"", (*v8go.Value).IsUndefined},
-		{"let v; v", (*v8go.Value).IsUndefined},
-		{"null", (*v8go.Value).IsNull},
-		{"let v; v", (*v8go.Value).IsNullOrUndefined},
-		{"let v = null; v", (*v8go.Value).IsNullOrUndefined},
-		{"true", (*v8go.Value).IsTrue},
-		{"false", (*v8go.Value).IsFalse},
-		{"'name'", (*v8go.Value).IsName},
-		{"Symbol()", (*v8go.Value).IsName},
-		{`"double quote"`, (*v8go.Value).IsString},
-		{"'single quote'", (*v8go.Value).IsString},
-		{"`string literal`", (*v8go.Value).IsString},
-		{"Symbol()", (*v8go.Value).IsSymbol},
-		{"Symbol('foo')", (*v8go.Value).IsSymbol},
-		{"() => {}", (*v8go.Value).IsFunction},
-		{"function v() {}; v", (*v8go.Value).IsFunction},
-		{"const v = function() {}; v", (*v8go.Value).IsFunction},
-		{"console.log", (*v8go.Value).IsFunction},
-		{"Object", (*v8go.Value).IsFunction},
-		{"class Foo {}; Foo", (*v8go.Value).IsFunction},
-		{"class Foo { bar() {} }; (new Foo()).bar", (*v8go.Value).IsFunction},
-		{"function* v(){}; v", (*v8go.Value).IsFunction},
-		{"async function v(){}; v", (*v8go.Value).IsFunction},
-		{"Object()", (*v8go.Value).IsObject},
-		{"new Object", (*v8go.Value).IsObject},
-		{"var v = {}; v", (*v8go.Value).IsObject},
-		{"10n", (*v8go.Value).IsBigInt},
-		{"BigInt(1)", (*v8go.Value).IsBigInt},
-		{"true", (*v8go.Value).IsBoolean},
-		{"false", (*v8go.Value).IsBoolean},
-		{"Boolean()", (*v8go.Value).IsBoolean},
-		{"(new Boolean).valueOf()", (*v8go.Value).IsBoolean},
-		{"1", (*v8go.Value).IsNumber},
-		{"1.1", (*v8go.Value).IsNumber},
-		{"1_1", (*v8go.Value).IsNumber},
-		{".1", (*v8go.Value).IsNumber},
-		{"2e4", (*v8go.Value).IsNumber},
-		{"0x2", (*v8go.Value).IsNumber},
-		{"NaN", (*v8go.Value).IsNumber},
-		{"Infinity", (*v8go.Value).IsNumber},
-		{"Number(1)", (*v8go.Value).IsNumber},
-		{"(new Number()).valueOf()", (*v8go.Value).IsNumber},
-		{"1", (*v8go.Value).IsInt32},
-		{"-1", (*v8go.Value).IsInt32},
-		{"1", (*v8go.Value).IsUint32},
-		{"new Date", (*v8go.Value).IsDate},
-		{"function foo(){ return arguments }; foo()", (*v8go.Value).IsArgumentsObject},
-		{"Object(1n)", (*v8go.Value).IsBigIntObject},
-		{"Object(1)", (*v8go.Value).IsNumberObject},
-		{"new Number", (*v8go.Value).IsNumberObject},
-		{"new String", (*v8go.Value).IsStringObject},
-		{"Object('')", (*v8go.Value).IsStringObject},
-		{"Object(Symbol())", (*v8go.Value).IsSymbolObject},
-		{"Error()", (*v8go.Value).IsNativeError},
-		{"TypeError()", (*v8go.Value).IsNativeError},
-		{"SyntaxError()", (*v8go.Value).IsNativeError},
-		{"/./", (*v8go.Value).IsRegExp},
-		{"RegExp()", (*v8go.Value).IsRegExp},
-		{"async function v(){}; v", (*v8go.Value).IsAsyncFunction},
-		{"let v = async () => {}; v", (*v8go.Value).IsAsyncFunction},
-		{"function* v(){}; v", (*v8go.Value).IsGeneratorFunction},
-		{"function* v(){}; v()", (*v8go.Value).IsGeneratorObject},
-		{"new Promise(()=>{})", (*v8go.Value).IsPromise},
-		{"new Map", (*v8go.Value).IsMap},
-		{"new Set", (*v8go.Value).IsSet},
-		{"(new Map).entries()", (*v8go.Value).IsMapIterator},
-		{"(new Set).entries()", (*v8go.Value).IsSetIterator},
-		{"new WeakMap", (*v8go.Value).IsWeakMap},
-		{"new WeakSet", (*v8go.Value).IsWeakSet},
-		{"new Array", (*v8go.Value).IsArray},
-		{"Array()", (*v8go.Value).IsArray},
-		{"[]", (*v8go.Value).IsArray},
-		{"new ArrayBuffer", (*v8go.Value).IsArrayBuffer},
-		{"new Int8Array", (*v8go.Value).IsArrayBufferView},
-		{"new Int8Array", (*v8go.Value).IsTypedArray},
-		{"new Uint32Array", (*v8go.Value).IsTypedArray},
-		{"new Uint8Array", (*v8go.Value).IsUint8Array},
-		{"new Uint8ClampedArray", (*v8go.Value).IsUint8ClampedArray},
-		{"new Int8Array", (*v8go.Value).IsInt8Array},
-		{"new Uint16Array", (*v8go.Value).IsUint16Array},
-		{"new Int16Array", (*v8go.Value).IsInt16Array},
-		{"new Uint32Array", (*v8go.Value).IsUint32Array},
-		{"new Int32Array", (*v8go.Value).IsInt32Array},
-		{"new Float32Array", (*v8go.Value).IsFloat32Array},
-		{"new Float64Array", (*v8go.Value).IsFloat64Array},
-		{"new BigInt64Array", (*v8go.Value).IsBigInt64Array},
-		{"new BigUint64Array", (*v8go.Value).IsBigUint64Array},
-		{"new DataView(new ArrayBuffer)", (*v8go.Value).IsDataView},
-		{"new SharedArrayBuffer", (*v8go.Value).IsSharedArrayBuffer},
-		{"new Proxy({},{})", (*v8go.Value).IsProxy},
+		{"", (*v8.Value).IsUndefined},
+		{"let v; v", (*v8.Value).IsUndefined},
+		{"null", (*v8.Value).IsNull},
+		{"let v; v", (*v8.Value).IsNullOrUndefined},
+		{"let v = null; v", (*v8.Value).IsNullOrUndefined},
+		{"true", (*v8.Value).IsTrue},
+		{"false", (*v8.Value).IsFalse},
+		{"'name'", (*v8.Value).IsName},
+		{"Symbol()", (*v8.Value).IsName},
+		{`"double quote"`, (*v8.Value).IsString},
+		{"'single quote'", (*v8.Value).IsString},
+		{"`string literal`", (*v8.Value).IsString},
+		{"Symbol()", (*v8.Value).IsSymbol},
+		{"Symbol('foo')", (*v8.Value).IsSymbol},
+		{"() => {}", (*v8.Value).IsFunction},
+		{"function v() {}; v", (*v8.Value).IsFunction},
+		{"const v = function() {}; v", (*v8.Value).IsFunction},
+		{"console.log", (*v8.Value).IsFunction},
+		{"Object", (*v8.Value).IsFunction},
+		{"class Foo {}; Foo", (*v8.Value).IsFunction},
+		{"class Foo { bar() {} }; (new Foo()).bar", (*v8.Value).IsFunction},
+		{"function* v(){}; v", (*v8.Value).IsFunction},
+		{"async function v(){}; v", (*v8.Value).IsFunction},
+		{"Object()", (*v8.Value).IsObject},
+		{"new Object", (*v8.Value).IsObject},
+		{"var v = {}; v", (*v8.Value).IsObject},
+		{"10n", (*v8.Value).IsBigInt},
+		{"BigInt(1)", (*v8.Value).IsBigInt},
+		{"true", (*v8.Value).IsBoolean},
+		{"false", (*v8.Value).IsBoolean},
+		{"Boolean()", (*v8.Value).IsBoolean},
+		{"(new Boolean).valueOf()", (*v8.Value).IsBoolean},
+		{"1", (*v8.Value).IsNumber},
+		{"1.1", (*v8.Value).IsNumber},
+		{"1_1", (*v8.Value).IsNumber},
+		{".1", (*v8.Value).IsNumber},
+		{"2e4", (*v8.Value).IsNumber},
+		{"0x2", (*v8.Value).IsNumber},
+		{"NaN", (*v8.Value).IsNumber},
+		{"Infinity", (*v8.Value).IsNumber},
+		{"Number(1)", (*v8.Value).IsNumber},
+		{"(new Number()).valueOf()", (*v8.Value).IsNumber},
+		{"1", (*v8.Value).IsInt32},
+		{"-1", (*v8.Value).IsInt32},
+		{"1", (*v8.Value).IsUint32},
+		{"new Date", (*v8.Value).IsDate},
+		{"function foo(){ return arguments }; foo()", (*v8.Value).IsArgumentsObject},
+		{"Object(1n)", (*v8.Value).IsBigIntObject},
+		{"Object(1)", (*v8.Value).IsNumberObject},
+		{"new Number", (*v8.Value).IsNumberObject},
+		{"new String", (*v8.Value).IsStringObject},
+		{"Object('')", (*v8.Value).IsStringObject},
+		{"Object(Symbol())", (*v8.Value).IsSymbolObject},
+		{"Error()", (*v8.Value).IsNativeError},
+		{"TypeError()", (*v8.Value).IsNativeError},
+		{"SyntaxError()", (*v8.Value).IsNativeError},
+		{"/./", (*v8.Value).IsRegExp},
+		{"RegExp()", (*v8.Value).IsRegExp},
+		{"async function v(){}; v", (*v8.Value).IsAsyncFunction},
+		{"let v = async () => {}; v", (*v8.Value).IsAsyncFunction},
+		{"function* v(){}; v", (*v8.Value).IsGeneratorFunction},
+		{"function* v(){}; v()", (*v8.Value).IsGeneratorObject},
+		{"new Promise(()=>{})", (*v8.Value).IsPromise},
+		{"new Map", (*v8.Value).IsMap},
+		{"new Set", (*v8.Value).IsSet},
+		{"(new Map).entries()", (*v8.Value).IsMapIterator},
+		{"(new Set).entries()", (*v8.Value).IsSetIterator},
+		{"new WeakMap", (*v8.Value).IsWeakMap},
+		{"new WeakSet", (*v8.Value).IsWeakSet},
+		{"new Array", (*v8.Value).IsArray},
+		{"Array()", (*v8.Value).IsArray},
+		{"[]", (*v8.Value).IsArray},
+		{"new ArrayBuffer", (*v8.Value).IsArrayBuffer},
+		{"new Int8Array", (*v8.Value).IsArrayBufferView},
+		{"new Int8Array", (*v8.Value).IsTypedArray},
+		{"new Uint32Array", (*v8.Value).IsTypedArray},
+		{"new Uint8Array", (*v8.Value).IsUint8Array},
+		{"new Uint8ClampedArray", (*v8.Value).IsUint8ClampedArray},
+		{"new Int8Array", (*v8.Value).IsInt8Array},
+		{"new Uint16Array", (*v8.Value).IsUint16Array},
+		{"new Int16Array", (*v8.Value).IsInt16Array},
+		{"new Uint32Array", (*v8.Value).IsUint32Array},
+		{"new Int32Array", (*v8.Value).IsInt32Array},
+		{"new Float32Array", (*v8.Value).IsFloat32Array},
+		{"new Float64Array", (*v8.Value).IsFloat64Array},
+		{"new BigInt64Array", (*v8.Value).IsBigInt64Array},
+		{"new BigUint64Array", (*v8.Value).IsBigUint64Array},
+		{"new DataView(new ArrayBuffer)", (*v8.Value).IsDataView},
+		{"new SharedArrayBuffer", (*v8.Value).IsSharedArrayBuffer},
+		{"new Proxy({},{})", (*v8.Value).IsProxy},
 	}
 	for _, tt := range tests {
 		tt := tt
 		t.Run(tt.source, func(t *testing.T) {
-			ctx := v8go.NewContext(iso)
+			ctx := v8.NewContext(iso)
 			defer ctx.Close()
 
 			val, err := ctx.RunScript(tt.source, "test.js")
@@ -612,25 +612,25 @@ func TestValueIsXXX(t *testing.T) {
 
 func TestValueMarshalJSON(t *testing.T) {
 	t.Parallel()
-	iso := v8go.NewIsolate()
+	iso := v8.NewIsolate()
 	defer iso.Dispose()
 
 	tests := [...]struct {
 		name     string
-		val      func(*v8go.Context) *v8go.Value
+		val      func(*v8.Context) *v8.Value
 		expected []byte
 	}{
 		{
 			"primitive",
-			func(ctx *v8go.Context) *v8go.Value {
-				val, _ := v8go.NewValue(iso, int32(0))
+			func(ctx *v8.Context) *v8.Value {
+				val, _ := v8.NewValue(iso, int32(0))
 				return val
 			},
 			[]byte("0"),
 		},
 		{
 			"object",
-			func(ctx *v8go.Context) *v8go.Value {
+			func(ctx *v8.Context) *v8.Value {
 				val, _ := ctx.RunScript("let foo = {a:1, b:2}; foo", "test.js")
 				return val
 			},
@@ -638,7 +638,7 @@ func TestValueMarshalJSON(t *testing.T) {
 		},
 		{
 			"objectFunc",
-			func(ctx *v8go.Context) *v8go.Value {
+			func(ctx *v8.Context) *v8.Value {
 				val, _ := ctx.RunScript("let foo = {a:1, b:()=>{}}; foo", "test.js")
 				return val
 			},
@@ -646,7 +646,7 @@ func TestValueMarshalJSON(t *testing.T) {
 		},
 		{
 			"nil",
-			func(ctx *v8go.Context) *v8go.Value { return nil },
+			func(ctx *v8.Context) *v8.Value { return nil },
 			[]byte(""),
 		},
 	}
@@ -654,7 +654,7 @@ func TestValueMarshalJSON(t *testing.T) {
 	for _, tt := range tests {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
-			ctx := v8go.NewContext(iso)
+			ctx := v8.NewContext(iso)
 			defer ctx.Close()
 			val := tt.val(ctx)
 			json, _ := val.MarshalJSON()


### PR DESCRIPTION
The `go` suffix makes sense in the context of the repository name, since it otherwise wouldn't be obvious from the url that it refers to Go bindings for v8.  However, when the library is imported, the `go` suffix becomes redundant since it is already in the context of go code.

As mentioned in the Go [Package names](https://go.dev/blog/package-names) blog post

> Good package names are short and clear.

So recommend importing the package as `v8` instead seems like better guidance for users of the library, without require a breaking change.

Note that we may want to consider moving the package to a `v8` subfolder in the repo to instead import using `import "rogchap.com/v8go/v8"`.  However, let's start with the recommendation, which if followed, will only require changes to the import lines if we moved the package to a subfolder like that in the future.