### PR TITLE
Introduce isolate's IsExecutionTerminating to wait for termination

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - value.SameValue(otherValue) function to compare values for sameness
 - Undefined, Null functions to get these constant values for the isolate
 - Support for calling a method on an object.
+- Support for calling `IsExecutionTerminating` on isolate to check if execution is still terminating.
 
 ### Changed
 - Removed error return value from NewIsolate which never fails

--- a/isolate.go
+++ b/isolate.go
@@ -68,6 +68,13 @@ func (i *Isolate) TerminateExecution() {
 	C.IsolateTerminateExecution(i.ptr)
 }
 
+// IsExecutionTerminating returns whether V8 is currently terminating
+// Javascript execution. If true, there are still JavaScript frames
+// on the stack and the termination exception is still active.
+func (i *Isolate) IsExecutionTerminating() bool {
+	return C.IsolateIsExecutionTerminating(i.ptr) == 1
+}
+
 // GetHeapStatistics returns heap statistics for an isolate.
 func (i *Isolate) GetHeapStatistics() HeapStatistics {
 	hs := C.IsolationGetHeapStatistics(i.ptr)

--- a/isolate_test.go
+++ b/isolate_test.go
@@ -36,7 +36,8 @@ func TestIsolateTermination(t *testing.T) {
 		iso.TerminateExecution()
 	}()
 
-	if e := <-err; e == nil || !strings.HasPrefix(e.Error(), "ExecutionTerminated") {
+	_, e := ctx.RunScript(`while (true) { }`, "forever.js")
+	if e == nil || !strings.HasPrefix(e.Error(), "ExecutionTerminated") {
 		t.Errorf("unexpected error: %v", e)
 	}
 	if iso.IsExecutionTerminating() {

--- a/isolate_test.go
+++ b/isolate_test.go
@@ -27,10 +27,7 @@ func TestIsolateTermination(t *testing.T) {
 
 	var terminating bool
 	fooFn := v8go.NewFunctionTemplate(iso, func(info *v8go.FunctionCallbackInfo) *v8go.Value {
-		ctx := info.Context()
-		obj := ctx.Global()
-		val, _ := obj.Get("loop")
-		loop, _ := val.AsFunction()
+		loop, _ := info.Args()[0].AsFunction()
 		loop.Call(v8go.Undefined(iso))
 
 		terminating = iso.IsExecutionTerminating()

--- a/isolate_test.go
+++ b/isolate_test.go
@@ -23,13 +23,6 @@ func TestIsolateTermination(t *testing.T) {
 	ctx := v8go.NewContext(iso)
 	defer ctx.Close()
 
-	err := make(chan error, 1)
-
-	go func() {
-		_, e := ctx.RunScript(`while (true) { }`, "forever.js")
-		err <- e
-	}()
-
 	go func() {
 		// [RC] find a better way to know when a script has started execution
 		time.Sleep(time.Millisecond)

--- a/isolate_test.go
+++ b/isolate_test.go
@@ -50,8 +50,7 @@ func TestIsolateTermination(t *testing.T) {
 	}()
 
 	script := `function loop() { while (true) { } }; foo(loop);`
-	val, e := ctx.RunScript(script, "forever.js")
-	fmt.Println(val)
+	_, e := ctx.RunScript(script, "forever.js")
 	if e == nil || !strings.HasPrefix(e.Error(), "ExecutionTerminated") {
 		t.Errorf("unexpected error: %v", e)
 	}

--- a/isolate_test.go
+++ b/isolate_test.go
@@ -39,6 +39,9 @@ func TestIsolateTermination(t *testing.T) {
 	if e := <-err; e == nil || !strings.HasPrefix(e.Error(), "ExecutionTerminated") {
 		t.Errorf("unexpected error: %v", e)
 	}
+	if iso.IsExecutionTerminating() {
+		t.Errorf("expect execution to be terminated")
+	}
 }
 
 func TestGetHeapStatistics(t *testing.T) {

--- a/v8go.cc
+++ b/v8go.cc
@@ -180,6 +180,11 @@ void IsolateTerminateExecution(IsolatePtr ptr) {
   iso->TerminateExecution();
 }
 
+int IsolateIsExecutionTerminating(IsolatePtr ptr) {
+  Isolate* iso = static_cast<Isolate*>(ptr);
+  return iso->IsExecutionTerminating();
+}
+
 IsolateHStatistics IsolationGetHeapStatistics(IsolatePtr ptr) {
   if (ptr == nullptr) {
     return IsolateHStatistics{0};

--- a/v8go.h
+++ b/v8go.h
@@ -53,6 +53,7 @@ extern IsolatePtr NewIsolate();
 extern void IsolatePerformMicrotaskCheckpoint(IsolatePtr ptr);
 extern void IsolateDispose(IsolatePtr ptr);
 extern void IsolateTerminateExecution(IsolatePtr ptr);
+extern int IsolateIsExecutionTerminating(IsolatePtr ptr);
 extern IsolateHStatistics IsolationGetHeapStatistics(IsolatePtr ptr);
 
 extern ContextPtr NewContext(IsolatePtr iso_ptr,


### PR DESCRIPTION
Introduce isolate's `IsExecutionTerminating()` to check if an execution is still terminating