### PR TITLE
Fix CI on forks by making the FOSSA step conditional on its secret

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,14 +40,14 @@ jobs:
     - name: Add GOPATH to GITHUB_ENV
       run: echo "GOPATH=$(go env GOPATH)" >>"$GITHUB_ENV"
     - name: Scan and upload FOSSA data (Linux/Mac)
-      if: github.ref == 'refs/heads/master' && matrix.platform != 'windows-latest'
+      if: env.FOSSA_API_KEY != '' && github.ref == 'refs/heads/master' && matrix.platform != 'windows-latest'
       run: |
         curl -H 'Cache-Control: no-cache' https://raw.githubusercontent.com/fossas/fossa-cli/master/install.sh | sudo bash
         fossa analyze
       env:
         FOSSA_API_KEY: ${{ secrets.FOSSA_API_KEY }}
     - name: Scan and upload FOSSA data (Windows)
-      if: github.ref == 'refs/heads/master' && matrix.platform == 'windows-latest'
+      if: env.FOSSA_API_KEY != '' && github.ref == 'refs/heads/master' && matrix.platform == 'windows-latest'
       run: |
         Set-ExecutionPolicy Bypass -Scope Process -Force; iex  ((New-Object System.Net.WebClient).DownloadString('https://raw.githubusercontent.com/fossas/fossa-cli/master/install.ps1'))
         C:\ProgramData\fossa-cli\fossa.exe analyze


### PR DESCRIPTION
cc @genevieve 

## Problem

It can be useful to enable Github Actions in a fork to test a branch on CI before opening a PR or without pushing debugging code to the PR branch.  However, when doing that, the "Scan and upload FOSSA data" CI steps will fail because they don't have the corresponding github secret.

The same problem comes up for anyone temporarily maintaining a fork of this repo to unblock themselves while they wait for a change to get accepted and merged in v8go.

## Solution

Make those steps conditional on the secret being provided.  This way nothing will need to be changed in the fork to workaround this problem.