### PR TITLE
Reduce unnecessary static casting of pointers received from Go

### DIFF
--- a/v8go.cc
+++ b/v8go.cc
@@ -125,8 +125,7 @@ extern "C" {
 
 /********** Isolate **********/
 
-#define ISOLATE_SCOPE(iso_ptr)                   \
-  Isolate* iso = iso_ptr;                        \
+#define ISOLATE_SCOPE(iso)                       \
   Locker locker(iso);                            \
   Isolate::Scope isolate_scope(iso);             \
   HandleScope handle_scope(iso);
@@ -163,8 +162,8 @@ static inline m_ctx* isolateInternalContext(Isolate *iso) {
   return static_cast<m_ctx*>(iso->GetData(0));
 }
 
-void IsolatePerformMicrotaskCheckpoint(IsolatePtr ptr) {
-  ISOLATE_SCOPE(ptr)
+void IsolatePerformMicrotaskCheckpoint(IsolatePtr iso) {
+  ISOLATE_SCOPE(iso)
   iso->PerformMicrotaskCheckpoint();
 }
 
@@ -280,8 +279,8 @@ RtnValue ObjectTemplateNewInstance(TemplatePtr ptr, ContextPtr ctx) {
 /********** FunctionTemplate **********/
 
 static void FunctionTemplateCallback(const FunctionCallbackInfo<Value>& info) {
-  Isolate* iso_ptr = info.GetIsolate();
-  ISOLATE_SCOPE(iso_ptr);
+  Isolate* iso = info.GetIsolate();
+  ISOLATE_SCOPE(iso);
 
   // This callback function can be called from any Context, which we only know
   // at runtime. We extract the Context reference from the embedder data so that
@@ -542,12 +541,12 @@ ValuePtr ContextGlobal(ContextPtr ctx_ptr) {
   Context::Scope context_scope(local_ctx);      \
   Local<Value> value = val->ptr.Get(iso);
 
-#define ISOLATE_SCOPE_INTERNAL_CONTEXT(iso_ptr) \
-  ISOLATE_SCOPE(iso_ptr);                       \
+#define ISOLATE_SCOPE_INTERNAL_CONTEXT(iso) \
+  ISOLATE_SCOPE(iso);                       \
   m_ctx* ctx = isolateInternalContext(iso);
 
-ValuePtr NewValueInteger(IsolatePtr iso_ptr, int32_t v) {
-  ISOLATE_SCOPE_INTERNAL_CONTEXT(iso_ptr);
+ValuePtr NewValueInteger(IsolatePtr iso, int32_t v) {
+  ISOLATE_SCOPE_INTERNAL_CONTEXT(iso);
   m_value* val = new m_value;
   val->iso = iso;
   val->ctx = ctx;
@@ -556,8 +555,8 @@ ValuePtr NewValueInteger(IsolatePtr iso_ptr, int32_t v) {
   return tracked_value(ctx, val);
 }
 
-ValuePtr NewValueIntegerFromUnsigned(IsolatePtr iso_ptr, uint32_t v) {
-  ISOLATE_SCOPE_INTERNAL_CONTEXT(iso_ptr);
+ValuePtr NewValueIntegerFromUnsigned(IsolatePtr iso, uint32_t v) {
+  ISOLATE_SCOPE_INTERNAL_CONTEXT(iso);
   m_value* val = new m_value;
   val->iso = iso;
   val->ctx = ctx;
@@ -566,8 +565,8 @@ ValuePtr NewValueIntegerFromUnsigned(IsolatePtr iso_ptr, uint32_t v) {
   return tracked_value(ctx, val);
 }
 
-RtnValue NewValueString(IsolatePtr iso_ptr, const char* v) {
-  ISOLATE_SCOPE_INTERNAL_CONTEXT(iso_ptr);
+RtnValue NewValueString(IsolatePtr iso, const char* v) {
+  ISOLATE_SCOPE_INTERNAL_CONTEXT(iso);
   TryCatch try_catch(iso);
   RtnValue rtn = {nullptr, nullptr};
   Local<String> str;
@@ -583,8 +582,8 @@ RtnValue NewValueString(IsolatePtr iso_ptr, const char* v) {
   return rtn;
 }
 
-ValuePtr NewValueNull(IsolatePtr iso_ptr) {
-  ISOLATE_SCOPE_INTERNAL_CONTEXT(iso_ptr);
+ValuePtr NewValueNull(IsolatePtr iso) {
+  ISOLATE_SCOPE_INTERNAL_CONTEXT(iso);
   m_value* val = new m_value;
   val->iso = iso;
   val->ctx = ctx;
@@ -592,8 +591,8 @@ ValuePtr NewValueNull(IsolatePtr iso_ptr) {
   return tracked_value(ctx, val);
 }
 
-ValuePtr NewValueUndefined(IsolatePtr iso_ptr) {
-  ISOLATE_SCOPE_INTERNAL_CONTEXT(iso_ptr);
+ValuePtr NewValueUndefined(IsolatePtr iso) {
+  ISOLATE_SCOPE_INTERNAL_CONTEXT(iso);
   m_value* val = new m_value;
   val->iso = iso;
   val->ctx = ctx;
@@ -602,8 +601,8 @@ ValuePtr NewValueUndefined(IsolatePtr iso_ptr) {
   return tracked_value(ctx, val);
 }
 
-ValuePtr NewValueBoolean(IsolatePtr iso_ptr, int v) {
-  ISOLATE_SCOPE_INTERNAL_CONTEXT(iso_ptr);
+ValuePtr NewValueBoolean(IsolatePtr iso, int v) {
+  ISOLATE_SCOPE_INTERNAL_CONTEXT(iso);
   m_value* val = new m_value;
   val->iso = iso;
   val->ctx = ctx;
@@ -612,8 +611,8 @@ ValuePtr NewValueBoolean(IsolatePtr iso_ptr, int v) {
   return tracked_value(ctx, val);
 }
 
-ValuePtr NewValueNumber(IsolatePtr iso_ptr, double v) {
-  ISOLATE_SCOPE_INTERNAL_CONTEXT(iso_ptr);
+ValuePtr NewValueNumber(IsolatePtr iso, double v) {
+  ISOLATE_SCOPE_INTERNAL_CONTEXT(iso);
   m_value* val = new m_value;
   val->iso = iso;
   val->ctx = ctx;
@@ -622,8 +621,8 @@ ValuePtr NewValueNumber(IsolatePtr iso_ptr, double v) {
   return tracked_value(ctx, val);
 }
 
-ValuePtr NewValueBigInt(IsolatePtr iso_ptr, int64_t v) {
-  ISOLATE_SCOPE_INTERNAL_CONTEXT(iso_ptr);
+ValuePtr NewValueBigInt(IsolatePtr iso, int64_t v) {
+  ISOLATE_SCOPE_INTERNAL_CONTEXT(iso);
   m_value* val = new m_value;
   val->iso = iso;
   val->ctx = ctx;
@@ -632,8 +631,8 @@ ValuePtr NewValueBigInt(IsolatePtr iso_ptr, int64_t v) {
   return tracked_value(ctx, val);
 }
 
-ValuePtr NewValueBigIntFromUnsigned(IsolatePtr iso_ptr, uint64_t v) {
-  ISOLATE_SCOPE_INTERNAL_CONTEXT(iso_ptr);
+ValuePtr NewValueBigIntFromUnsigned(IsolatePtr iso, uint64_t v) {
+  ISOLATE_SCOPE_INTERNAL_CONTEXT(iso);
   m_value* val = new m_value;
   val->iso = iso;
   val->ctx = ctx;
@@ -642,11 +641,11 @@ ValuePtr NewValueBigIntFromUnsigned(IsolatePtr iso_ptr, uint64_t v) {
   return tracked_value(ctx, val);
 }
 
-RtnValue NewValueBigIntFromWords(IsolatePtr iso_ptr,
+RtnValue NewValueBigIntFromWords(IsolatePtr iso,
                                  int sign_bit,
                                  int word_count,
                                  const uint64_t* words) {
-  ISOLATE_SCOPE_INTERNAL_CONTEXT(iso_ptr);
+  ISOLATE_SCOPE_INTERNAL_CONTEXT(iso);
   TryCatch try_catch(iso);
   Local<Context> local_ctx = ctx->ptr.Get(iso);
 
@@ -755,7 +754,8 @@ RtnValue ValueToObject(ValuePtr ptr) {
 }
 
 int ValueSameValue(ValuePtr val1, ValuePtr val2) {
-  ISOLATE_SCOPE(val1->iso);
+  Isolate* iso = val1->iso;
+  ISOLATE_SCOPE(iso);
   Local<Value> value1 = val1->ptr.Get(iso);
   Local<Value> value2 = val2->ptr.Get(iso);
 

--- a/v8go.cc
+++ b/v8go.cc
@@ -523,8 +523,7 @@ ValuePtr ContextGlobal(ContextPtr ctx_ptr) {
 
 /********** Value **********/
 
-#define LOCAL_VALUE(ptr)                        \
-  m_value* val = ptr;                           \
+#define LOCAL_VALUE(val)                        \
   Isolate* iso = val->iso;                      \
   Locker locker(iso);                           \
   Isolate::Scope isolate_scope(iso);            \

--- a/v8go.cc
+++ b/v8go.cc
@@ -206,13 +206,12 @@ IsolateHStatistics IsolationGetHeapStatistics(IsolatePtr iso) {
 
 /********** Template **********/
 
-#define LOCAL_TEMPLATE(ptr)                       \
-  m_template* ot = ptr;                           \
-  Isolate* iso = ot->iso;                         \
+#define LOCAL_TEMPLATE(tmpl_ptr)                  \
+  Isolate* iso = tmpl_ptr->iso;                   \
   Locker locker(iso);                             \
   Isolate::Scope isolate_scope(iso);              \
   HandleScope handle_scope(iso);                  \
-  Local<Template> tmpl = ot->ptr.Get(iso);
+  Local<Template> tmpl = tmpl_ptr->ptr.Get(iso);
 
 void TemplateFree(TemplatePtr ptr) {
   delete ptr;

--- a/v8go.cc
+++ b/v8go.cc
@@ -363,8 +363,7 @@ RtnValue FunctionTemplateGetFunction(TemplatePtr ptr, ContextPtr ctx) {
 
 /********** Context **********/
 
-#define LOCAL_CONTEXT(ctx_ptr)                  \
-  m_ctx* ctx = ctx_ptr;                         \
+#define LOCAL_CONTEXT(ctx)                      \
   Isolate* iso = ctx->iso;                      \
   Locker locker(iso);                           \
   Isolate::Scope isolate_scope(iso);            \
@@ -415,8 +414,8 @@ void ContextFree(ContextPtr ctx) {
   delete ctx;
 }
 
-RtnValue RunScript(ContextPtr ctx_ptr, const char* source, const char* origin) {
-  LOCAL_CONTEXT(ctx_ptr);
+RtnValue RunScript(ContextPtr ctx, const char* source, const char* origin) {
+  LOCAL_CONTEXT(ctx);
 
   RtnValue rtn = {nullptr, nullptr};
 
@@ -450,8 +449,8 @@ RtnValue RunScript(ContextPtr ctx_ptr, const char* source, const char* origin) {
   return rtn;
 }
 
-RtnValue JSONParse(ContextPtr ctx_ptr, const char* str) {
-  LOCAL_CONTEXT(ctx_ptr);
+RtnValue JSONParse(ContextPtr ctx, const char* str) {
+  LOCAL_CONTEXT(ctx);
   RtnValue rtn = {nullptr, nullptr};
 
   Local<String> v8Str;
@@ -508,8 +507,8 @@ const char* JSONStringify(ContextPtr ctx, ValuePtr val) {
   return CopyString(json);
 }
 
-ValuePtr ContextGlobal(ContextPtr ctx_ptr) {
-  LOCAL_CONTEXT(ctx_ptr);
+ValuePtr ContextGlobal(ContextPtr ctx) {
+  LOCAL_CONTEXT(ctx);
   m_value* val = new m_value;
 
   val->iso = iso;
@@ -1118,8 +1117,8 @@ int ObjectDeleteIdx(ValuePtr ptr, uint32_t idx) {
 
 /********** Promise **********/
 
-RtnValue NewPromiseResolver(ContextPtr ctx_ptr) {
-  LOCAL_CONTEXT(ctx_ptr);
+RtnValue NewPromiseResolver(ContextPtr ctx) {
+  LOCAL_CONTEXT(ctx);
   RtnValue rtn = {nullptr, nullptr};
   Local<Promise::Resolver> resolver;
   if (!Promise::Resolver::New(local_ctx).ToLocal(&resolver)) {

--- a/v8go.cc
+++ b/v8go.cc
@@ -126,7 +126,7 @@ extern "C" {
 /********** Isolate **********/
 
 #define ISOLATE_SCOPE(iso_ptr)                   \
-  Isolate* iso = static_cast<Isolate*>(iso_ptr); \
+  Isolate* iso = iso_ptr;                        \
   Locker locker(iso);                            \
   Isolate::Scope isolate_scope(iso);             \
   HandleScope handle_scope(iso);
@@ -156,7 +156,7 @@ IsolatePtr NewIsolate() {
   ctx->iso = iso;
   iso->SetData(0, ctx);
 
-  return static_cast<IsolatePtr>(iso);
+  return iso;
 }
 
 static inline m_ctx* isolateInternalContext(Isolate *iso) {
@@ -168,31 +168,27 @@ void IsolatePerformMicrotaskCheckpoint(IsolatePtr ptr) {
   iso->PerformMicrotaskCheckpoint();
 }
 
-void IsolateDispose(IsolatePtr ptr) {
-  if (ptr == nullptr) {
+void IsolateDispose(IsolatePtr iso) {
+  if (iso == nullptr) {
     return;
   }
-  Isolate* iso = static_cast<Isolate*>(ptr);
   ContextFree(isolateInternalContext(iso));
 
   iso->Dispose();
 }
 
-void IsolateTerminateExecution(IsolatePtr ptr) {
-  Isolate* iso = static_cast<Isolate*>(ptr);
+void IsolateTerminateExecution(IsolatePtr iso) {
   iso->TerminateExecution();
 }
 
-int IsolateIsExecutionTerminating(IsolatePtr ptr) {
-  Isolate* iso = static_cast<Isolate*>(ptr);
+int IsolateIsExecutionTerminating(IsolatePtr iso) {
   return iso->IsExecutionTerminating();
 }
 
-IsolateHStatistics IsolationGetHeapStatistics(IsolatePtr ptr) {
-  if (ptr == nullptr) {
+IsolateHStatistics IsolationGetHeapStatistics(IsolatePtr iso) {
+  if (iso == nullptr) {
     return IsolateHStatistics{0};
   }
-  Isolate* iso = static_cast<Isolate*>(ptr);
   v8::HeapStatistics hs;
   iso->GetHeapStatistics(&hs);
 
@@ -247,8 +243,7 @@ void TemplateSetTemplate(TemplatePtr ptr,
 
 /********** ObjectTemplate **********/
 
-TemplatePtr NewObjectTemplate(IsolatePtr iso_ptr) {
-  Isolate* iso = static_cast<Isolate*>(iso_ptr);
+TemplatePtr NewObjectTemplate(IsolatePtr iso) {
   Locker locker(iso);
   Isolate::Scope isolate_scope(iso);
   HandleScope handle_scope(iso);
@@ -328,8 +323,7 @@ static void FunctionTemplateCallback(const FunctionCallbackInfo<Value>& info) {
   }
 }
 
-TemplatePtr NewFunctionTemplate(IsolatePtr iso_ptr, int callback_ref) {
-  Isolate* iso = static_cast<Isolate*>(iso_ptr);
+TemplatePtr NewFunctionTemplate(IsolatePtr iso, int callback_ref) {
   Locker locker(iso);
   Isolate::Scope isolate_scope(iso);
   HandleScope handle_scope(iso);
@@ -381,10 +375,9 @@ RtnValue FunctionTemplateGetFunction(TemplatePtr ptr, ContextPtr ctx) {
   Local<Context> local_ctx = ctx->ptr.Get(iso); \
   Context::Scope context_scope(local_ctx);
 
-ContextPtr NewContext(IsolatePtr iso_ptr,
+ContextPtr NewContext(IsolatePtr iso,
                       TemplatePtr global_template_ptr,
                       int ref) {
-  Isolate* iso = static_cast<Isolate*>(iso_ptr);
   Locker locker(iso);
   Isolate::Scope isolate_scope(iso);
   HandleScope handle_scope(iso);

--- a/v8go.cc
+++ b/v8go.cc
@@ -125,9 +125,9 @@ extern "C" {
 
 /********** Isolate **********/
 
-#define ISOLATE_SCOPE(iso)                       \
-  Locker locker(iso);                            \
-  Isolate::Scope isolate_scope(iso);             \
+#define ISOLATE_SCOPE(iso)           \
+  Locker locker(iso);                \
+  Isolate::Scope isolate_scope(iso); \
   HandleScope handle_scope(iso);
 
 void Init() {
@@ -158,7 +158,7 @@ IsolatePtr NewIsolate() {
   return iso;
 }
 
-static inline m_ctx* isolateInternalContext(Isolate *iso) {
+static inline m_ctx* isolateInternalContext(Isolate* iso) {
   return static_cast<m_ctx*>(iso->GetData(0));
 }
 
@@ -206,11 +206,11 @@ IsolateHStatistics IsolationGetHeapStatistics(IsolatePtr iso) {
 
 /********** Template **********/
 
-#define LOCAL_TEMPLATE(tmpl_ptr)                  \
-  Isolate* iso = tmpl_ptr->iso;                   \
-  Locker locker(iso);                             \
-  Isolate::Scope isolate_scope(iso);              \
-  HandleScope handle_scope(iso);                  \
+#define LOCAL_TEMPLATE(tmpl_ptr)     \
+  Isolate* iso = tmpl_ptr->iso;      \
+  Locker locker(iso);                \
+  Isolate::Scope isolate_scope(iso); \
+  HandleScope handle_scope(iso);     \
   Local<Template> tmpl = tmpl_ptr->ptr.Get(iso);
 
 void TemplateFree(TemplatePtr ptr) {
@@ -310,10 +310,10 @@ static void FunctionTemplateCallback(const FunctionCallbackInfo<Value>& info) {
     args[i] = tracked_value(ctx, val);
   }
 
-  ValuePtr goFunctionCallback(int ctxref, int cbref, const ValuePtr* thisAndArgs,
-                              int args_count);
-  ValuePtr val = goFunctionCallback(
-      ctx_ref, callback_ref, thisAndArgs, args_count);
+  ValuePtr goFunctionCallback(int ctxref, int cbref,
+                              const ValuePtr* thisAndArgs, int args_count);
+  ValuePtr val =
+      goFunctionCallback(ctx_ref, callback_ref, thisAndArgs, args_count);
   if (val != nullptr) {
     info.GetReturnValue().Set(val->ptr.Get(iso));
   } else {
@@ -521,21 +521,21 @@ ValuePtr ContextGlobal(ContextPtr ctx) {
 
 /********** Value **********/
 
-#define LOCAL_VALUE(val)                        \
-  Isolate* iso = val->iso;                      \
-  Locker locker(iso);                           \
-  Isolate::Scope isolate_scope(iso);            \
-  HandleScope handle_scope(iso);                \
-  TryCatch try_catch(iso);                      \
-  m_ctx* ctx = val->ctx;                        \
-  Local<Context> local_ctx;                     \
-  if (ctx != nullptr) {                         \
-    local_ctx = ctx->ptr.Get(iso);              \
-  } else {                                      \
-    ctx = isolateInternalContext(iso);          \
-    local_ctx = ctx->ptr.Get(iso);              \
-  }                                             \
-  Context::Scope context_scope(local_ctx);      \
+#define LOCAL_VALUE(val)                   \
+  Isolate* iso = val->iso;                 \
+  Locker locker(iso);                      \
+  Isolate::Scope isolate_scope(iso);       \
+  HandleScope handle_scope(iso);           \
+  TryCatch try_catch(iso);                 \
+  m_ctx* ctx = val->ctx;                   \
+  Local<Context> local_ctx;                \
+  if (ctx != nullptr) {                    \
+    local_ctx = ctx->ptr.Get(iso);         \
+  } else {                                 \
+    ctx = isolateInternalContext(iso);     \
+    local_ctx = ctx->ptr.Get(iso);         \
+  }                                        \
+  Context::Scope context_scope(local_ctx); \
   Local<Value> value = val->ptr.Get(iso);
 
 #define ISOLATE_SCOPE_INTERNAL_CONTEXT(iso) \
@@ -708,8 +708,10 @@ RtnString ValueToDetailString(ValuePtr ptr) {
 
 const char* ValueToString(ValuePtr ptr) {
   LOCAL_VALUE(ptr);
-  // String::Utf8Value will result in an empty string if conversion to a string fails
-  // TODO: Consider propagating the JS error. A fallback value could be returned in Value.String()
+  // String::Utf8Value will result in an empty string if conversion to a string
+  // fails
+  // TODO: Consider propagating the JS error. A fallback value could be returned
+  // in Value.String()
   String::Utf8Value utf8(iso, value);
   return CopyString(utf8);
 }

--- a/v8go.cc
+++ b/v8go.cc
@@ -161,6 +161,10 @@ IsolatePtr NewIsolate() {
   return static_cast<IsolatePtr>(iso);
 }
 
+static inline m_ctx* isolateInternalContext(Isolate *iso) {
+  return static_cast<m_ctx*>(iso->GetData(0));
+}
+
 void IsolatePerformMicrotaskCheckpoint(IsolatePtr ptr) {
   ISOLATE_SCOPE(ptr)
   iso->PerformMicrotaskCheckpoint();
@@ -171,7 +175,7 @@ void IsolateDispose(IsolatePtr ptr) {
     return;
   }
   Isolate* iso = static_cast<Isolate*>(ptr);
-  ContextFree(iso->GetData(0));
+  ContextFree(isolateInternalContext(iso));
 
   iso->Dispose();
 }
@@ -514,7 +518,7 @@ const char* JSONStringify(ContextPtr ctx_ptr, ValuePtr val_ptr) {
     if (val->ctx != nullptr) {
       local_ctx = val->ctx->ptr.Get(iso);
     } else {
-      m_ctx* ctx = static_cast<m_ctx*>(iso->GetData(0));
+      m_ctx* ctx = isolateInternalContext(iso);
       local_ctx = ctx->ptr.Get(iso);
     }
   }
@@ -555,7 +559,7 @@ ValuePtr ContextGlobal(ContextPtr ctx_ptr) {
   if (ctx != nullptr) {                         \
     local_ctx = ctx->ptr.Get(iso);              \
   } else {                                      \
-    ctx = static_cast<m_ctx*>(iso->GetData(0)); \
+    ctx = isolateInternalContext(iso);          \
     local_ctx = ctx->ptr.Get(iso);              \
   }                                             \
   Context::Scope context_scope(local_ctx);      \
@@ -563,7 +567,7 @@ ValuePtr ContextGlobal(ContextPtr ctx_ptr) {
 
 #define ISOLATE_SCOPE_INTERNAL_CONTEXT(iso_ptr) \
   ISOLATE_SCOPE(iso_ptr);                       \
-  m_ctx* ctx = static_cast<m_ctx*>(iso->GetData(0));
+  m_ctx* ctx = isolateInternalContext(iso);
 
 ValuePtr NewValueInteger(IsolatePtr iso_ptr, int32_t v) {
   ISOLATE_SCOPE_INTERNAL_CONTEXT(iso_ptr);

--- a/v8go.h
+++ b/v8go.h
@@ -7,7 +7,7 @@
 #ifdef __cplusplus
 
 namespace v8 {
-  class Isolate;
+class Isolate;
 }
 
 typedef v8::Isolate* IsolatePtr;
@@ -21,8 +21,6 @@ typedef v8Isolate* IsolatePtr;
 
 #include <stddef.h>
 #include <stdint.h>
-
-
 
 typedef struct m_ctx m_ctx;
 typedef struct m_value m_value;
@@ -44,7 +42,7 @@ typedef struct {
 } RtnValue;
 
 typedef struct {
-  const char *string;
+  const char* string;
   RtnError error;
 } RtnString;
 
@@ -202,7 +200,10 @@ RtnValue PromiseThen2(ValuePtr ptr, int on_fulfilled_ref, int on_rejected_ref);
 RtnValue PromiseCatch(ValuePtr ptr, int callback_ref);
 extern ValuePtr PromiseResult(ValuePtr ptr);
 
-extern RtnValue FunctionCall(ValuePtr ptr, ValuePtr recv, int argc, ValuePtr argv[]);
+extern RtnValue FunctionCall(ValuePtr ptr,
+                             ValuePtr recv,
+                             int argc,
+                             ValuePtr argv[]);
 RtnValue FunctionNewInstance(ValuePtr ptr, int argc, ValuePtr args[]);
 ValuePtr FunctionSourceMapUrl(ValuePtr ptr);
 

--- a/v8go.h
+++ b/v8go.h
@@ -102,7 +102,6 @@ extern RtnValue NewValueBigIntFromWords(IsolatePtr iso_ptr,
                                         int sign_bit,
                                         int word_count,
                                         const uint64_t* words);
-extern void ValueFree(ValuePtr ptr);
 const char* ValueToString(ValuePtr ptr);
 const uint32_t* ValueToArrayIndex(ValuePtr ptr);
 int ValueToBoolean(ValuePtr ptr);

--- a/v8go.h
+++ b/v8go.h
@@ -6,17 +6,28 @@
 #define V8GO_H
 #ifdef __cplusplus
 
+namespace v8 {
+  class Isolate;
+}
+
+typedef v8::Isolate* IsolatePtr;
+
 extern "C" {
+#else
+// Opaque to cgo, but useful to treat it as a pointer to a distinct type
+typedef struct v8Isolate v8Isolate;
+typedef v8Isolate* IsolatePtr;
 #endif
 
 #include <stddef.h>
 #include <stdint.h>
 
+
+
 typedef struct m_ctx m_ctx;
 typedef struct m_value m_value;
 typedef struct m_template m_template;
 
-typedef void* IsolatePtr;
 typedef m_ctx* ContextPtr;
 typedef m_value* ValuePtr;
 typedef m_template* TemplatePtr;

--- a/v8go.h
+++ b/v8go.h
@@ -12,10 +12,14 @@ extern "C" {
 #include <stddef.h>
 #include <stdint.h>
 
+typedef struct m_ctx m_ctx;
+typedef struct m_value m_value;
+typedef struct m_template m_template;
+
 typedef void* IsolatePtr;
-typedef void* ContextPtr;
-typedef void* ValuePtr;
-typedef void* TemplatePtr;
+typedef m_ctx* ContextPtr;
+typedef m_value* ValuePtr;
+typedef m_template* TemplatePtr;
 
 typedef struct {
   const char* msg;


### PR DESCRIPTION
## Problem

There was a lot of use of void pointers because of the pointer types defined in v8go.h for the C API exposed to Go.  This results in a lot of use of static_cast, which is verbose and is less type safe (since the pointer could just as easily be cast to the wrong pointer type)

## Solution

Forward declare the types in v8go.h without defining them, so Go will treat the pointers as pointers to opaque structs, but they will be pointers to the correct type in v8go.cc.

I couldn't do a forward declaration for `v8::Isolate` when compiling with C, so I used conditional compilation to just forward declare it for c++.  For C, we just want a distinct struct type for the pointer to help avoid mixing pointers.

I also moved `static_cast<m_ctx*>(iso->GetData(0))` to both reduce places where this static cast is done as well as to leverage the name of the function (`isolateInternalContext `) to make the code more readable.