### PR TITLE
Add valueResult to get the value and error from C results

### DIFF
--- a/context.go
+++ b/context.go
@@ -167,29 +167,26 @@ func goContext(ref int) C.ContextPtr {
 
 func valueResult(ctx *Context, rtn C.RtnValue) (*Value, error) {
 	if rtn.value == nil {
-		return nil, getError(rtn)
+		return nil, getError(rtn.error)
 	}
 	return &Value{rtn.value, ctx}, nil
 }
 
 func objectResult(ctx *Context, rtn C.RtnValue) (*Object, error) {
 	if rtn.value == nil {
-		return nil, getError(rtn)
+		return nil, getError(rtn.error)
 	}
 	return &Object{&Value{rtn.value, ctx}}, nil
 }
 
-func getError(rtn C.RtnValue) error {
-	if rtn.error.msg == nil {
-		return nil
-	}
+func getError(rtnErr C.RtnError) error {
 	err := &JSError{
-		Message:    C.GoString(rtn.error.msg),
-		Location:   C.GoString(rtn.error.location),
-		StackTrace: C.GoString(rtn.error.stack),
+		Message:    C.GoString(rtnErr.msg),
+		Location:   C.GoString(rtnErr.location),
+		StackTrace: C.GoString(rtnErr.stack),
 	}
-	C.free(unsafe.Pointer(rtn.error.msg))
-	C.free(unsafe.Pointer(rtn.error.location))
-	C.free(unsafe.Pointer(rtn.error.stack))
+	C.free(unsafe.Pointer(rtnErr.msg))
+	C.free(unsafe.Pointer(rtnErr.location))
+	C.free(unsafe.Pointer(rtnErr.stack))
 	return err
 }

--- a/context.go
+++ b/context.go
@@ -94,7 +94,7 @@ func (c *Context) RunScript(source string, origin string) (*Value, error) {
 	rtn := C.RunScript(c.ptr, cSource, cOrigin)
 	c.deregister()
 
-	return getValue(c, rtn), getError(rtn)
+	return valueResult(c, rtn)
 }
 
 // Global returns the global proxy object.
@@ -165,18 +165,18 @@ func goContext(ref int) C.ContextPtr {
 	return ctx.ptr
 }
 
-func getValue(ctx *Context, rtn C.RtnValue) *Value {
+func valueResult(ctx *Context, rtn C.RtnValue) (*Value, error) {
 	if rtn.value == nil {
-		return nil
+		return nil, getError(rtn)
 	}
-	return &Value{rtn.value, ctx}
+	return &Value{rtn.value, ctx}, nil
 }
 
-func getObject(ctx *Context, rtn C.RtnValue) *Object {
+func objectResult(ctx *Context, rtn C.RtnValue) (*Object, error) {
 	if rtn.value == nil {
-		return nil
+		return nil, getError(rtn)
 	}
-	return &Object{&Value{rtn.value, ctx}}
+	return &Object{&Value{rtn.value, ctx}}, nil
 }
 
 func getError(rtn C.RtnValue) error {

--- a/context.go
+++ b/context.go
@@ -167,26 +167,14 @@ func goContext(ref int) C.ContextPtr {
 
 func valueResult(ctx *Context, rtn C.RtnValue) (*Value, error) {
 	if rtn.value == nil {
-		return nil, getError(rtn.error)
+		return nil, newJSError(rtn.error)
 	}
 	return &Value{rtn.value, ctx}, nil
 }
 
 func objectResult(ctx *Context, rtn C.RtnValue) (*Object, error) {
 	if rtn.value == nil {
-		return nil, getError(rtn.error)
+		return nil, newJSError(rtn.error)
 	}
 	return &Object{&Value{rtn.value, ctx}}, nil
-}
-
-func getError(rtnErr C.RtnError) error {
-	err := &JSError{
-		Message:    C.GoString(rtnErr.msg),
-		Location:   C.GoString(rtnErr.location),
-		StackTrace: C.GoString(rtnErr.stack),
-	}
-	C.free(unsafe.Pointer(rtnErr.msg))
-	C.free(unsafe.Pointer(rtnErr.location))
-	C.free(unsafe.Pointer(rtnErr.stack))
-	return err
 }

--- a/errors.go
+++ b/errors.go
@@ -4,9 +4,13 @@
 
 package v8go
 
+// #include <stdlib.h>
+// #include "v8go.h"
+import "C"
 import (
 	"fmt"
 	"io"
+	"unsafe"
 )
 
 // JSError is an error that is returned if there is are any
@@ -16,6 +20,18 @@ type JSError struct {
 	Message    string
 	Location   string
 	StackTrace string
+}
+
+func newJSError(rtnErr C.RtnError) error {
+	err := &JSError{
+		Message:    C.GoString(rtnErr.msg),
+		Location:   C.GoString(rtnErr.location),
+		StackTrace: C.GoString(rtnErr.stack),
+	}
+	C.free(unsafe.Pointer(rtnErr.msg))
+	C.free(unsafe.Pointer(rtnErr.location))
+	C.free(unsafe.Pointer(rtnErr.stack))
+	return err
 }
 
 func (e *JSError) Error() string {

--- a/function.go
+++ b/function.go
@@ -28,7 +28,7 @@ func (fn *Function) Call(recv Valuer, args ...Valuer) (*Value, error) {
 	fn.ctx.register()
 	rtn := C.FunctionCall(fn.ptr, recv.value().ptr, C.int(len(args)), argptr)
 	fn.ctx.deregister()
-	return getValue(fn.ctx, rtn), getError(rtn)
+	return valueResult(fn.ctx, rtn)
 }
 
 // Invoke a constructor function to create an object instance.
@@ -44,7 +44,7 @@ func (fn *Function) NewInstance(args ...Valuer) (*Object, error) {
 	fn.ctx.register()
 	rtn := C.FunctionNewInstance(fn.ptr, C.int(len(args)), argptr)
 	fn.ctx.deregister()
-	return getObject(fn.ctx, rtn), getError(rtn)
+	return objectResult(fn.ctx, rtn)
 }
 
 // Return the source map url for a function.

--- a/json.go
+++ b/json.go
@@ -22,7 +22,7 @@ func JSONParse(ctx *Context, str string) (*Value, error) {
 	defer C.free(unsafe.Pointer(cstr))
 
 	rtn := C.JSONParse(ctx.ptr, cstr)
-	return getValue(ctx, rtn), getError(rtn)
+	return valueResult(ctx, rtn)
 }
 
 // JSONStringify tries to stringify the JSON-serializable object value and returns it as string.

--- a/object.go
+++ b/object.go
@@ -24,11 +24,11 @@ func (o *Object) MethodCall(methodName string, args ...Valuer) (*Value, error) {
 	defer C.free(unsafe.Pointer(ckey))
 
 	getRtn := C.ObjectGet(o.ptr, ckey)
-	err := getError(getRtn)
+	prop, err := valueResult(o.ctx, getRtn)
 	if err != nil {
 		return nil, err
 	}
-	fn, err := getValue(o.ctx, getRtn).AsFunction()
+	fn, err := prop.AsFunction()
 	if err != nil {
 		return nil, err
 	}
@@ -84,13 +84,13 @@ func (o *Object) Get(key string) (*Value, error) {
 	defer C.free(unsafe.Pointer(ckey))
 
 	rtn := C.ObjectGet(o.ptr, ckey)
-	return getValue(o.ctx, rtn), getError(rtn)
+	return valueResult(o.ctx, rtn)
 }
 
 // GetIdx tries to get a Value at a give Object index.
 func (o *Object) GetIdx(idx uint32) (*Value, error) {
 	rtn := C.ObjectGetIdx(o.ptr, C.uint32_t(idx))
-	return getValue(o.ctx, rtn), getError(rtn)
+	return valueResult(o.ctx, rtn)
 }
 
 // Has calls the abstract operation HasProperty(O, P) described in ECMA-262, 7.3.10.


### PR DESCRIPTION
I was going to propagate more errors as a follow-up to #177, but I noticed the internal Go API was have to do that could be improved.

We had several return statements like `return getValue(c, rtn), getError(rtn)` in the Go code to convert the cgo results into and `(*v8.Value, error)` return value.  These two function calls are tightly coupled to the same `C.RtnValue` argument so it would be more idiomatic in Go to just have a single function that returns the `(*v8.Value, error)` result we want to propagate.  So this PR adds a `valueResult` function to do just that.