### PR TITLE
Fix crashes from template finalizer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Add some missing error propagation
 - Fix crash from template finalizer releasing V8 data, let it be disposed with the isolate
+- Fix crash by keeping alive the template while its C++ pointer is still being used
 
 ## [v0.6.0] - 2021-05-11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Add some missing error propagation
+- Fix crash from template finalizer releasing V8 data, let it be disposed with the isolate
 
 ## [v0.6.0] - 2021-05-11
 

--- a/context.go
+++ b/context.go
@@ -8,6 +8,7 @@ package v8go
 // #include "v8go.h"
 import "C"
 import (
+	"runtime"
 	"sync"
 	"unsafe"
 )
@@ -72,6 +73,7 @@ func NewContext(opt ...ContextOption) *Context {
 		ptr: C.NewContext(opts.iso.ptr, opts.gTmpl.ptr, C.int(ref)),
 		iso: opts.iso,
 	}
+	runtime.KeepAlive(opts.gTmpl)
 	return ctx
 }
 

--- a/function_template.go
+++ b/function_template.go
@@ -66,6 +66,7 @@ func NewFunctionTemplate(iso *Isolate, callback FunctionCallback) *FunctionTempl
 // GetFunction returns an instance of this function template bound to the given context.
 func (tmpl *FunctionTemplate) GetFunction(ctx *Context) *Function {
 	rtn := C.FunctionTemplateGetFunction(tmpl.ptr, ctx.ptr)
+	runtime.KeepAlive(tmpl)
 	val, err := valueResult(ctx, rtn)
 	if err != nil {
 		panic(err) // TODO: Consider returning the error

--- a/object_template.go
+++ b/object_template.go
@@ -56,6 +56,7 @@ func (o *ObjectTemplate) NewInstance(ctx *Context) (*Object, error) {
 	}
 
 	rtn := C.ObjectTemplateNewInstance(o.ptr, ctx.ptr)
+	runtime.KeepAlive(o)
 	return objectResult(ctx, rtn)
 }
 

--- a/template.go
+++ b/template.go
@@ -11,6 +11,7 @@ import (
 	"errors"
 	"fmt"
 	"math/big"
+	"runtime"
 	"unsafe"
 )
 
@@ -41,8 +42,10 @@ func (t *template) Set(name string, val interface{}, attributes ...PropertyAttri
 		C.TemplateSetValue(t.ptr, cname, newVal.ptr, C.int(attrs))
 	case *ObjectTemplate:
 		C.TemplateSetTemplate(t.ptr, cname, v.ptr, C.int(attrs))
+		runtime.KeepAlive(v)
 	case *FunctionTemplate:
 		C.TemplateSetTemplate(t.ptr, cname, v.ptr, C.int(attrs))
+		runtime.KeepAlive(v)
 	case *Value:
 		if v.IsObject() || v.IsExternal() {
 			return errors.New("v8go: unsupported property: value type must be a primitive or use a template")
@@ -51,6 +54,7 @@ func (t *template) Set(name string, val interface{}, attributes ...PropertyAttri
 	default:
 		return fmt.Errorf("v8go: unsupported property type `%T`, must be one of string, int32, uint32, int64, uint64, float64, *big.Int, *v8go.Value, *v8go.ObjectTemplate or *v8go.FunctionTemplate", v)
 	}
+	runtime.KeepAlive(t)
 
 	return nil
 }

--- a/template.go
+++ b/template.go
@@ -11,7 +11,6 @@ import (
 	"errors"
 	"fmt"
 	"math/big"
-	"runtime"
 	"unsafe"
 )
 
@@ -57,7 +56,9 @@ func (t *template) Set(name string, val interface{}, attributes ...PropertyAttri
 }
 
 func (t *template) finalizer() {
-	C.TemplateFree(t.ptr)
+	// Using v8::PersistentBase::Reset() wouldn't be thread-safe to do from
+	// this finalizer goroutine so just free the wrapper and let the template
+	// itself get cleaned up when the isolate is disposed.
+	C.TemplateFreeWrapper(t.ptr)
 	t.ptr = nil
-	runtime.SetFinalizer(t, nil)
 }

--- a/v8go.cc
+++ b/v8go.cc
@@ -213,8 +213,9 @@ IsolateHStatistics IsolationGetHeapStatistics(IsolatePtr iso) {
   HandleScope handle_scope(iso);     \
   Local<Template> tmpl = tmpl_ptr->ptr.Get(iso);
 
-void TemplateFree(TemplatePtr ptr) {
-  delete ptr;
+void TemplateFreeWrapper(TemplatePtr tmpl) {
+  tmpl->ptr.Empty();  // Just does `val_ = 0;` without calling V8::DisposeGlobal
+  delete tmpl;
 }
 
 void TemplateSetValue(TemplatePtr ptr,

--- a/v8go.h
+++ b/v8go.h
@@ -85,7 +85,7 @@ extern RtnValue JSONParse(ContextPtr ctx_ptr, const char* str);
 const char* JSONStringify(ContextPtr ctx_ptr, ValuePtr val_ptr);
 extern ValuePtr ContextGlobal(ContextPtr ctx_ptr);
 
-extern void TemplateFree(TemplatePtr ptr);
+extern void TemplateFreeWrapper(TemplatePtr ptr);
 extern void TemplateSetValue(TemplatePtr ptr,
                              const char* name,
                              ValuePtr val_ptr,


### PR DESCRIPTION
## Problem

We ran into fairly reproducible crashes from benchmarking code that was creating (and initializing) new isolates frequently, often in C.TemplateSetTemplate, where the value being set was a v8go.FunctionTemplate.  At first, I thought this might have been from a race condition from the finalizer running in a separate goroutine, which I thought was the reason other uses of finalizers was removed from v8go, but it happened even when the finalizer only freed the wrapper struct (m_template).  It looks like there was also a problem with the `template` becoming garbage after `template.ptr` is obtained from it, even before `template.ptr` is passed into the C function (e.g. `C.TemplateSetTemplate`).

## Solution

To avoid the finalizer goroutine race condition, I changed the finalizer to only free the template wrapper struct.   v8::Template resides in the V8 heap (i.e. it is v8::Data), so it should get freed when the isolate is disposed.  In the future, the solution for #105 should allow this v8::Data to be released earlier.

The second commit in this PR uses runtime.KeepAlive to avoid the template Go struct from being garbage collected before the `template.ptr` is finished being used.

I tested this in our application benchmark that was crashing and this seems to have fixed the crashes.