### PR TITLE
Add a context.Context field to v8go.Context for idiomatic Go embedder data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Undefined, Null functions to get these constant values for the isolate
 - Support for calling a method on an object.
 - Support for calling `IsExecutionTerminating` on isolate to check if execution is still terminating.
+- Context.EmbedderContext context.Context field for idiomatic Go embedder data
 
 ### Changed
 - Removed error return value from NewIsolate which never fails

--- a/context.go
+++ b/context.go
@@ -8,6 +8,7 @@ package v8go
 // #include "v8go.h"
 import "C"
 import (
+	"context"
 	"runtime"
 	"sync"
 	"unsafe"
@@ -30,9 +31,10 @@ var ctxSeq = 0
 // Context is a global root execution environment that allows separate,
 // unrelated, JavaScript applications to run in a single instance of V8.
 type Context struct {
-	ref int
-	ptr C.ContextPtr
-	iso *Isolate
+	EmbedderContext context.Context
+	ref             int
+	ptr             C.ContextPtr
+	iso             *Isolate
 }
 
 type contextOptions struct {
@@ -69,9 +71,10 @@ func NewContext(opt ...ContextOption) *Context {
 	ctxMutex.Unlock()
 
 	ctx := &Context{
-		ref: ref,
-		ptr: C.NewContext(opts.iso.ptr, opts.gTmpl.ptr, C.int(ref)),
-		iso: opts.iso,
+		EmbedderContext: context.Background(),
+		ref:             ref,
+		ptr:             C.NewContext(opts.iso.ptr, opts.gTmpl.ptr, C.int(ref)),
+		iso:             opts.iso,
 	}
 	runtime.KeepAlive(opts.gTmpl)
 	return ctx


### PR DESCRIPTION
## Problem

We would like to use an isolate to perform multiple isolated tasks in parallel, with each task being independently cancellable, having its own deadline and having its own metadata associated with it.  However, when a `FunctionTemplate` that is re-used across these tasks is called, then we get a v8go.Context without a clear way of getting the associated task information.

There are a number of workarounds that seem awkward, not obvious and add unnecessary overhead:
* Storing a key in a v8 value stored on the global object to use for looking up the associated task
* Using a new FunctionTemplate per-task (the "template" in its name effectively becomes a misnomer)
* Using the v8go.Context itself as a key to lookup the task from a map

V8 has the concept of Embedder Data that can be associated with a context for this purpose, so it seems like v8go should expose this sort of capability.  Although, using the v8 embedder data capability itself would be awkward, since we want to be able to store arbitrary Go values instead of C++ values.

## Solution

The solution is quite simple, we just expose a field on the v8go.Context that can be set by the code using the library (the embedder) then easily retrieved in a function callback.

Theoretically, this field could be an `EmbedderData interface{}` field, which would then need to be cast to the concrete type before using.  However, there may be different packages that provide different APIs (e.g. a generic polyfill library and an application specific APIs) that could all need to share the context's embedder data.

As such, this PR adds a `EmbedderContext context.Context` field to the v8go.Context, which would allows different packages to provide APIs that would better interoperate, with a common API for deadlines and cancellation as well as having a common object that isolated state can be attached to in a non-conflicting way using `context.WithValue` (e.g. could be done using each package's `InjectToContext` function).

If an application really only needs an `interface{}` field, then they could always leverage the fact that `context.Context` is just an interface to treat EmbedderContext almost like it is an `interface{}` type.  This just requires adding a `context.Context` field to the application's struct, which could be initialized with `Context: context.Background()` for this fields value.  However, it seems quite likely that they will actually want to use it as a `context.Context`.