### PR TITLE
Fix function callback usage outside of `RunScript`

### DIFF
--- a/context.go
+++ b/context.go
@@ -91,9 +91,7 @@ func (c *Context) RunScript(source string, origin string) (*Value, error) {
 	defer C.free(unsafe.Pointer(cSource))
 	defer C.free(unsafe.Pointer(cOrigin))
 
-	c.register()
 	rtn := C.RunScript(c.ptr, cSource, cOrigin)
-	c.deregister()
 
 	return valueResult(c, rtn)
 }

--- a/context.go
+++ b/context.go
@@ -116,7 +116,7 @@ func (c *Context) PerformMicrotaskCheckpoint() {
 }
 
 // Close will dispose the context and free the memory.
-// Access to any values assosiated with the context after calling Close may panic.
+// Access to any values associated with the context after calling Close may panic.
 func (c *Context) Close() {
 	c.deregister()
 	C.ContextFree(c.ptr)

--- a/context_test.go
+++ b/context_test.go
@@ -123,14 +123,10 @@ func TestRegistryFromJSON(t *testing.T) {
 	global := v8.NewObjectTemplate(iso)
 	err := global.Set("location", v8.NewFunctionTemplate(iso, func(info *v8.FunctionCallbackInfo) *v8.Value {
 		v, err := v8.NewValue(iso, "world")
-		if err != nil {
-			t.Errorf("creating return value: %v", err)
-		}
+		failIf(t, err)
 		return v
 	}))
-	if err != nil {
-		t.Errorf("setting global: %v", err)
-	}
+	failIf(t, err)
 
 	ctx := v8.NewContext(iso, global)
 	defer ctx.Close()
@@ -144,17 +140,14 @@ func TestRegistryFromJSON(t *testing.T) {
 			},
 		})
 	`, "main.js")
-	if err != nil {
-		t.Errorf("running script: %v", err)
-	}
+	failIf(t, err)
 
 	s, err := v8.JSONStringify(ctx, v)
-	if err != nil {
-		t.Errorf("stringifying value: %v", err)
-	}
+	failIf(t, err)
 
-	if s != `{"hello":"world"}` {
-		t.Errorf("unexpected stringified value: %s", s)
+	expected := `{"hello":"world"}`
+	if s != expected {
+		t.Fatalf("expected %q, got %q", expected, s)
 	}
 }
 

--- a/export_test.go
+++ b/export_test.go
@@ -14,16 +14,6 @@ func (i *Isolate) GetCallback(ref int) FunctionCallback {
 	return i.getCallback(ref)
 }
 
-// Register is exported for testing only.
-func (c *Context) Register() {
-	c.register()
-}
-
-// Deregister is exported for testing only.
-func (c *Context) Deregister() {
-	c.deregister()
-}
-
 // GetContext is exported for testing only.
 var GetContext = getContext
 

--- a/function.go
+++ b/function.go
@@ -25,9 +25,7 @@ func (fn *Function) Call(recv Valuer, args ...Valuer) (*Value, error) {
 		}
 		argptr = (*C.ValuePtr)(unsafe.Pointer(&cArgs[0]))
 	}
-	fn.ctx.register()
 	rtn := C.FunctionCall(fn.ptr, recv.value().ptr, C.int(len(args)), argptr)
-	fn.ctx.deregister()
 	return valueResult(fn.ctx, rtn)
 }
 
@@ -41,9 +39,7 @@ func (fn *Function) NewInstance(args ...Valuer) (*Object, error) {
 		}
 		argptr = (*C.ValuePtr)(unsafe.Pointer(&cArgs[0]))
 	}
-	fn.ctx.register()
 	rtn := C.FunctionNewInstance(fn.ptr, C.int(len(args)), argptr)
-	fn.ctx.deregister()
 	return objectResult(fn.ctx, rtn)
 }
 

--- a/promise.go
+++ b/promise.go
@@ -62,16 +62,12 @@ func (r *PromiseResolver) GetPromise() *Promise {
 // Resolve invokes the Promise resolve state with the given value.
 // The Promise state will transition from Pending to Fulfilled.
 func (r *PromiseResolver) Resolve(val Valuer) bool {
-	r.ctx.register()
-	defer r.ctx.deregister()
 	return C.PromiseResolverResolve(r.ptr, val.value().ptr) != 0
 }
 
 // Reject invokes the Promise reject state with the given value.
 // The Promise state will transition from Pending to Rejected.
 func (r *PromiseResolver) Reject(err *Value) bool {
-	r.ctx.register()
-	defer r.ctx.deregister()
 	return C.PromiseResolverReject(r.ptr, err.ptr) != 0
 }
 
@@ -98,9 +94,6 @@ func (p *Promise) Result() *Value {
 // The default MicrotaskPolicy processes them when the call depth decreases to 0.
 // Call (*Context).PerformMicrotaskCheckpoint to trigger it manually.
 func (p *Promise) Then(cbs ...FunctionCallback) *Promise {
-	p.ctx.register()
-	defer p.ctx.deregister()
-
 	var rtn C.RtnValue
 	switch len(cbs) {
 	case 1:
@@ -124,8 +117,6 @@ func (p *Promise) Then(cbs ...FunctionCallback) *Promise {
 // Catch invokes the given function if the promise is rejected.
 // See Then for other details.
 func (p *Promise) Catch(cb FunctionCallback) *Promise {
-	p.ctx.register()
-	defer p.ctx.deregister()
 	cbID := p.ctx.iso.registerCallback(cb)
 	rtn := C.PromiseCatch(p.ptr, C.int(cbID))
 	obj, err := objectResult(p.ctx, rtn)


### PR DESCRIPTION
This fixes an issue where you could not access function callbacks outside of `RunScript` since the context registry would not have been updated.

Fixes: https://github.com/rogchap/v8go/issues/186