### PR TITLE
Rename failIf test helper to fatalIf since it uses t.Fatal

### DIFF
--- a/context_test.go
+++ b/context_test.go
@@ -123,10 +123,10 @@ func TestRegistryFromJSON(t *testing.T) {
 	global := v8.NewObjectTemplate(iso)
 	err := global.Set("location", v8.NewFunctionTemplate(iso, func(info *v8.FunctionCallbackInfo) *v8.Value {
 		v, err := v8.NewValue(iso, "world")
-		failIf(t, err)
+		fatalIf(t, err)
 		return v
 	}))
-	failIf(t, err)
+	fatalIf(t, err)
 
 	ctx := v8.NewContext(iso, global)
 	defer ctx.Close()
@@ -140,10 +140,10 @@ func TestRegistryFromJSON(t *testing.T) {
 			},
 		})
 	`, "main.js")
-	failIf(t, err)
+	fatalIf(t, err)
 
 	s, err := v8.JSONStringify(ctx, v)
-	failIf(t, err)
+	fatalIf(t, err)
 
 	expected := `{"hello":"world"}`
 	if s != expected {

--- a/function_test.go
+++ b/function_test.go
@@ -18,17 +18,17 @@ func TestFunctionCall(t *testing.T) {
 	defer ctx.Close()
 
 	_, err := ctx.RunScript("function add(a, b) { return a + b; }", "")
-	failIf(t, err)
+	fatalIf(t, err)
 	addValue, err := ctx.Global().Get("add")
-	failIf(t, err)
+	fatalIf(t, err)
 	iso := ctx.Isolate()
 
 	arg1, err := v8.NewValue(iso, int32(1))
-	failIf(t, err)
+	fatalIf(t, err)
 
 	fn, _ := addValue.AsFunction()
 	resultValue, err := fn.Call(v8.Undefined(iso), arg1, arg1)
-	failIf(t, err)
+	fatalIf(t, err)
 
 	if resultValue.Int32() != 2 {
 		t.Errorf("expected 1 + 1 = 2, got: %v", resultValue.DetailString())
@@ -49,17 +49,17 @@ func TestFunctionCallToGoFunc(t *testing.T) {
 	})
 
 	err := global.Set("print", printfn, v8.ReadOnly)
-	failIf(t, err)
+	fatalIf(t, err)
 
 	ctx := v8.NewContext(iso, global)
 	defer ctx.Close()
 
 	val, err := ctx.RunScript(`(a, b) => { print("foo"); }`, "")
-	failIf(t, err)
+	fatalIf(t, err)
 	fn, err := val.AsFunction()
-	failIf(t, err)
+	fatalIf(t, err)
 	resultValue, err := fn.Call(v8.Undefined(iso))
-	failIf(t, err)
+	fatalIf(t, err)
 
 	if !called {
 		t.Errorf("expected my function to be called, wasn't")
@@ -77,15 +77,15 @@ func TestFunctionCallWithObjectReceiver(t *testing.T) {
 
 	ctx := v8.NewContext(iso, global)
 	val, err := ctx.RunScript(`class Obj { constructor(input) { this.input = input } print() { return this.input.toString() } }; new Obj("some val")`, "")
-	failIf(t, err)
+	fatalIf(t, err)
 	obj, err := val.AsObject()
-	failIf(t, err)
+	fatalIf(t, err)
 	fnVal, err := obj.Get("print")
-	failIf(t, err)
+	fatalIf(t, err)
 	fn, err := fnVal.AsFunction()
-	failIf(t, err)
+	fatalIf(t, err)
 	resultValue, err := fn.Call(obj)
-	failIf(t, err)
+	fatalIf(t, err)
 
 	if !resultValue.IsString() || resultValue.String() != "some val" {
 		t.Errorf("expected 'some val', got: %v", resultValue.DetailString())
@@ -101,9 +101,9 @@ func TestFunctionCallError(t *testing.T) {
 	defer ctx.Close()
 
 	_, err := ctx.RunScript("function throws() { throw 'error'; }", "script.js")
-	failIf(t, err)
+	fatalIf(t, err)
 	addValue, err := ctx.Global().Get("throws")
-	failIf(t, err)
+	fatalIf(t, err)
 
 	fn, _ := addValue.AsFunction()
 	_, err = fn.Call(v8.Undefined(iso))
@@ -124,9 +124,9 @@ func TestFunctionSourceMapUrl(t *testing.T) {
 	defer ctx.Isolate().Dispose()
 	defer ctx.Close()
 	_, err := ctx.RunScript("function add(a, b) { return a + b; }; //# sourceMappingURL=main.js.map", "main.js")
-	failIf(t, err)
+	fatalIf(t, err)
 	addValue, err := ctx.Global().Get("add")
-	failIf(t, err)
+	fatalIf(t, err)
 
 	fn, _ := addValue.AsFunction()
 
@@ -136,9 +136,9 @@ func TestFunctionSourceMapUrl(t *testing.T) {
 	}
 
 	_, err = ctx.RunScript("function sub(a, b) { return a - b; };", "")
-	failIf(t, err)
+	fatalIf(t, err)
 	subValue, err := ctx.Global().Get("sub")
-	failIf(t, err)
+	fatalIf(t, err)
 
 	subFn, _ := subValue.AsFunction()
 	resultVal = subFn.SourceMapUrl()
@@ -157,16 +157,16 @@ func TestFunctionNewInstance(t *testing.T) {
 	iso := ctx.Isolate()
 
 	value, err := ctx.Global().Get("Error")
-	failIf(t, err)
+	fatalIf(t, err)
 	fn, err := value.AsFunction()
-	failIf(t, err)
+	fatalIf(t, err)
 	messageObj, err := v8.NewValue(iso, "test message")
-	failIf(t, err)
+	fatalIf(t, err)
 	errObj, err := fn.NewInstance(messageObj)
-	failIf(t, err)
+	fatalIf(t, err)
 
 	message, err := errObj.Get("message")
-	failIf(t, err)
+	fatalIf(t, err)
 	if !message.IsString() {
 		t.Error("missing error message")
 	}
@@ -185,9 +185,9 @@ func TestFunctionNewInstanceError(t *testing.T) {
 	defer ctx.Close()
 
 	_, err := ctx.RunScript("function throws() { throw 'error'; }", "script.js")
-	failIf(t, err)
+	fatalIf(t, err)
 	throwsValue, err := ctx.Global().Get("throws")
-	failIf(t, err)
+	fatalIf(t, err)
 	fn, _ := throwsValue.AsFunction()
 
 	_, err = fn.NewInstance()

--- a/helpers_test.go
+++ b/helpers_test.go
@@ -2,7 +2,7 @@ package v8go_test
 
 import "testing"
 
-func failIf(t *testing.T, err error) {
+func fatalIf(t *testing.T, err error) {
 	t.Helper()
 	if err != nil {
 		t.Fatal(err)

--- a/object_test.go
+++ b/object_test.go
@@ -19,7 +19,7 @@ func TestObjectMethodCall(t *testing.T) {
 	val, _ := ctx.RunScript(`class Obj { constructor(input) { this.input = input, this.prop = "" } print() { return this.input.toString() } }; new Obj("some val")`, "")
 	obj, _ := val.AsObject()
 	val, err := obj.MethodCall("print")
-	failIf(t, err)
+	fatalIf(t, err)
 	if val.String() != "some val" {
 		t.Errorf("unexpected value: %q", val)
 	}
@@ -29,11 +29,11 @@ func TestObjectMethodCall(t *testing.T) {
 	}
 
 	val, err = ctx.RunScript(`class Obj2 { print(str) { return str.toString() }; get fails() { throw "error" } }; new Obj2()`, "")
-	failIf(t, err)
+	fatalIf(t, err)
 	obj, _ = val.AsObject()
 	arg, _ := v8.NewValue(iso, "arg")
 	val, err = obj.MethodCall("print", arg)
-	failIf(t, err)
+	fatalIf(t, err)
 	if val.String() != "arg" {
 		t.Errorf("unexpected value: %q", val)
 	}

--- a/value_test.go
+++ b/value_test.go
@@ -181,7 +181,7 @@ func TestValueConstants(t *testing.T) {
 		tt := tt
 
 		val, err := ctx.RunScript(tt.source, "test.js")
-		failIf(t, err)
+		fatalIf(t, err)
 
 		if tt.value.SameValue(val) != tt.same {
 			t.Errorf("SameValue on JS `%s` and V8 value %+v didn't return %v",
@@ -482,9 +482,9 @@ func TestValueSameValue(t *testing.T) {
 
 	objTempl := v8.NewObjectTemplate(iso)
 	obj1, err := objTempl.NewInstance(ctx)
-	failIf(t, err)
+	fatalIf(t, err)
 	obj2, err := objTempl.NewInstance(ctx)
-	failIf(t, err)
+	fatalIf(t, err)
 
 	if obj1.Value.SameValue(obj2.Value) != false {
 		t.Errorf("SameValue on two different values didn't return false")


### PR DESCRIPTION
## Problem

The testing package has both t.Fail and t.Fatal, so calling the test helper method failIf makes it seem like it would call t.Fail and continue executing when it actually calls t.Fatal.

## Solution

Renaming to fatalIf will make its behaviour clearer without looking at its implementation.