### PR TITLE
move import for include vendor.go files inside include/vendor.go

### DIFF
--- a/cgo.go
+++ b/cgo.go
@@ -19,8 +19,6 @@ import "C"
 import (
 	_ "rogchap.com/v8go/deps/darwin_x86_64"
 	_ "rogchap.com/v8go/deps/include"
-	_ "rogchap.com/v8go/deps/include/cppgc"
-	_ "rogchap.com/v8go/deps/include/libplatform"
 	_ "rogchap.com/v8go/deps/linux_x86_64"
 	_ "rogchap.com/v8go/deps/windows_x86_64"
 )

--- a/deps/include/vendor.go
+++ b/deps/include/vendor.go
@@ -1,3 +1,8 @@
 // Package include is required to provide support for vendoring modules
 // DO NOT REMOVE
 package include
+
+import (
+	_ "rogchap.com/v8go/deps/include/cppgc"
+	_ "rogchap.com/v8go/deps/include/libplatform"
+)


### PR DESCRIPTION
While working on https://github.com/rogchap/v8go/pull/181 @dylanahsmith suggested that we should move the import for the nested `deps/include/**/vendor.go` from the `cgo.go` file to the `deps/include/vendor.go` that way when using the `upgrade.py` script to [upgrade the v8 binaries](https://github.com/rogchap/v8go#upgrading-the-v8-binaries) we avoid having to regenerate the `cgo.go` file. 

This could avoid us having to worry about deleting any manual change to the `cgo.go`. Since all the `deps/include` file are going to be managed by the `upgrade.py` there is fewer chances of that from happening.

cc @dylanahsmith @rogchap @genevieve 
