### PR TITLE
Remove v8 redeclarations in v8go.h

### DIFF
--- a/v8go.cc
+++ b/v8go.cc
@@ -13,14 +13,6 @@
 #include <string>
 #include <vector>
 
-#if defined(__MINGW32__) || defined(__MINGW64__)
-// MinGW header files do not implicitly include windows.h
-struct _EXCEPTION_POINTERS;
-#endif
-
-#include "libplatform/libplatform.h"
-#include "v8.h"
-#include "v8-profiler.h"
 #include "_cgo_export.h"
 
 using namespace v8;

--- a/v8go.h
+++ b/v8go.h
@@ -6,12 +6,14 @@
 #define V8GO_H
 #ifdef __cplusplus
 
-namespace v8 {
-class Isolate;
-class CpuProfiler;
-class CpuProfile;
-class CpuProfileNode;
-}
+#if defined(__MINGW32__) || defined(__MINGW64__)
+// MinGW header files do not implicitly include windows.h
+struct _EXCEPTION_POINTERS;
+#endif
+
+#include "libplatform/libplatform.h"
+#include "v8.h"
+#include "v8-profiler.h"
 
 typedef v8::Isolate* IsolatePtr;
 typedef v8::CpuProfiler* CpuProfilerPtr;


### PR DESCRIPTION
Instead, we can just include v8.h itself to define these when compiling with C++, which is just simpler and allows it to work with nested classes