### PR TITLE
Make sure to include the v8 version in autogenerated commit and PR description

### DIFF
--- a/.github/workflows/v8upgrade.yml
+++ b/.github/workflows/v8upgrade.yml
@@ -31,7 +31,7 @@ jobs:
               run: |
                 echo ::set-output name=pr_branch::"v8_$(cat deps/v8_version)_upgrade"
                 echo ::set-output name=pr_commit_message::"Upgrade V8 binaries for $(cat deps/v8_version) version"
-                echo ::set-output name=pr_body::"Auto-generated pull request to upgarde V8 binary for $(cat deps/v8_version) version"
+                echo ::set-output name=pr_body::"Auto-generated pull request to upgrade V8 binary for $(cat deps/v8_version) version"
             - name: Create PR
               uses: peter-evans/create-pull-request@v3
               with:


### PR DESCRIPTION
To avoid confusion when the upgrade workflow runs, we can add the v8 version to the autogenerated PR, that way if we haven't merged one of the autogenerated PRs and the workflows runs and find a new stable version, we are going to be able to see which PR is the latest one.

Here is how the autogenerated PR looks like:
![image](https://user-images.githubusercontent.com/4672858/138771464-3ffab389-7046-4029-b0cb-e3a7e8141f67.png)

Ultimately, I think we could make the upgrade workflow to close any old upgrade PR that haven't been merged if a new stable v8 version is released.
