### PR TITLE
Fix a couple of cpu profile memory leaks

### DIFF
--- a/v8go.cc
+++ b/v8go.cc
@@ -286,6 +286,7 @@ void CPUProfileNodeDelete(CPUProfileNode* node) {
     CPUProfileNodeDelete(node->children[i]);
   }
 
+  delete[] node->children;
   delete node;
 }
 
@@ -294,6 +295,7 @@ void CPUProfileDelete(CPUProfile* profile) {
     return;
   }
   profile->ptr->Delete();
+  free((void *)profile->title);
 
   CPUProfileNodeDelete(profile->root);
 


### PR DESCRIPTION
## Problem

I tried using valgrind to check for leaks in v8go and found some in the cpu profiling code that can be reproduced using `go test -c && valgrind --leak-check=full --show-leak-kinds=definite --track-origins=yes ./v8go.test -test.run=TestCPUProfile` (run on linux with valgrind already installed)

Here are the unique leaks that valgrind detected

```
==321754== 8 bytes in 1 blocks are definitely lost in loss record 569 of 894
==321754==    at 0x483C583: operator new[](unsigned long) (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
==321754==    by 0xA8169D: NewCPUProfileNode (v8go.cc:239)
==321754==    by 0xA89EC4: CPUProfilerStopProfiling (v8go.cc:275)
==321754==    by 0xA7F55E: _cgo_eb9c209376d5_Cfunc_CPUProfilerStopProfiling (cgo-gcc-prolog:78)
==321754==    by 0x8705AF: runtime.asmcgocall.abi0 (asm_amd64.s:765)
==321754==    by 0xC000027FFF: ???
==321754==    by 0x2DFECDD7: ???
==321754==    by 0x849117: runtime.exitsyscallfast.func1 (proc.go:4017)
==321754==    by 0x86E708: runtime.systemstack.abi0 (asm_amd64.s:383)
==321754==
==321754== 8 bytes in 2 blocks are definitely lost in loss record 570 of 894
==321754==    at 0x483C583: operator new[](unsigned long) (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
==321754==    by 0xA8169D: NewCPUProfileNode (v8go.cc:239)
==321754==    by 0xA816BB: NewCPUProfileNode (v8go.cc:241)
==321754==    by 0xA89EC4: CPUProfilerStopProfiling (v8go.cc:275)
==321754==    by 0xA7F55E: _cgo_eb9c209376d5_Cfunc_CPUProfilerStopProfiling (cgo-gcc-prolog:78)
==321754==    by 0x8705AF: runtime.asmcgocall.abi0 (asm_amd64.s:765)
==321754==    by 0x1A0C7BF: ???
==321754==    by 0x1: ???
==321754==    by 0xC000044DCF: ???
```

## Solution

I added the missing `delete` for the C++ allocated memory and `free` for the `malloc` allocated memory.