### PR TITLE
Fix mismatched C free of memory allocated with C++ new

### DIFF
--- a/v8go.cc
+++ b/v8go.cc
@@ -230,7 +230,9 @@ void CPUProfilerStartProfiling(CPUProfiler* profiler, const char* title) {
   Isolate::Scope isolate_scope(profiler->iso);
   HandleScope handle_scope(profiler->iso);
 
-  Local<String> title_str = String::NewFromUtf8(profiler->iso, title, NewStringType::kNormal).ToLocalChecked();
+  Local<String> title_str =
+      String::NewFromUtf8(profiler->iso, title, NewStringType::kNormal)
+          .ToLocalChecked();
   profiler->ptr->StartProfiling(title_str);
 }
 
@@ -242,13 +244,13 @@ CPUProfileNode* NewCPUProfileNode(const CpuProfileNode* ptr_) {
   }
 
   CPUProfileNode* root = new CPUProfileNode{
-    ptr_,
-    ptr_->GetScriptResourceNameStr(),
-    ptr_->GetFunctionNameStr(),
-    ptr_->GetLineNumber(),
-    ptr_->GetColumnNumber(),
-    count,
-    children,
+      ptr_,
+      ptr_->GetScriptResourceNameStr(),
+      ptr_->GetFunctionNameStr(),
+      ptr_->GetLineNumber(),
+      ptr_->GetColumnNumber(),
+      count,
+      children,
   };
   return root;
 }
@@ -263,7 +265,8 @@ CPUProfile* CPUProfilerStopProfiling(CPUProfiler* profiler, const char* title) {
   HandleScope handle_scope(profiler->iso);
 
   Local<String> title_str =
-      String::NewFromUtf8(profiler->iso, title, NewStringType::kNormal).ToLocalChecked();
+      String::NewFromUtf8(profiler->iso, title, NewStringType::kNormal)
+          .ToLocalChecked();
 
   CPUProfile* profile = new CPUProfile;
   profile->ptr = profiler->ptr->StopProfiling(title_str);
@@ -295,7 +298,7 @@ void CPUProfileDelete(CPUProfile* profile) {
     return;
   }
   profile->ptr->Delete();
-  free((void *)profile->title);
+  free((void*)profile->title);
 
   CPUProfileNodeDelete(profile->root);
 
@@ -374,7 +377,8 @@ RtnValue ObjectTemplateNewInstance(TemplatePtr ptr, ContextPtr ctx) {
   return rtn;
 }
 
-void ObjectTemplateSetInternalFieldCount(TemplatePtr ptr, uint32_t field_count) {
+void ObjectTemplateSetInternalFieldCount(TemplatePtr ptr,
+                                         uint32_t field_count) {
   LOCAL_TEMPLATE(ptr);
 
   Local<ObjectTemplate> obj_tmpl = tmpl.As<ObjectTemplate>();
@@ -1214,8 +1218,8 @@ ValuePtr ObjectGetInternalField(ValuePtr ptr, uint32_t idx) {
   m_value* new_val = new m_value;
   new_val->iso = iso;
   new_val->ctx = ctx;
-  new_val->ptr = Persistent<Value, CopyablePersistentTraits<Value>>(
-      iso, result);
+  new_val->ptr =
+      Persistent<Value, CopyablePersistentTraits<Value>>(iso, result);
 
   return tracked_value(ctx, new_val);
 }

--- a/v8go.cc
+++ b/v8go.cc
@@ -778,7 +778,7 @@ const uint32_t* ValueToArrayIndex(ValuePtr ptr) {
     return nullptr;
   }
 
-  uint32_t* idx = new uint32_t;
+  uint32_t* idx = (uint32_t*)malloc(sizeof(uint32_t));
   *idx = array_index->Value();
   return idx;
 }
@@ -840,7 +840,7 @@ ValueBigInt ValueToBigInt(ValuePtr ptr) {
 
   int word_count = bint->WordCount();
   int sign_bit = 0;
-  uint64_t* words = new uint64_t[word_count];
+  uint64_t* words = (uint64_t*)malloc(sizeof(uint64_t) * word_count);
   bint->ToWordsArray(&sign_bit, &word_count, words);
   ValueBigInt rtn = {words, word_count, sign_bit};
   return rtn;

--- a/v8go.h
+++ b/v8go.h
@@ -12,8 +12,8 @@ struct _EXCEPTION_POINTERS;
 #endif
 
 #include "libplatform/libplatform.h"
-#include "v8.h"
 #include "v8-profiler.h"
+#include "v8.h"
 
 typedef v8::Isolate* IsolatePtr;
 typedef v8::CpuProfiler* CpuProfilerPtr;
@@ -117,7 +117,8 @@ extern IsolateHStatistics IsolationGetHeapStatistics(IsolatePtr ptr);
 extern CPUProfiler* NewCPUProfiler(IsolatePtr iso_ptr);
 extern void CPUProfilerDispose(CPUProfiler* ptr);
 extern void CPUProfilerStartProfiling(CPUProfiler* ptr, const char* title);
-extern CPUProfile* CPUProfilerStopProfiling(CPUProfiler* ptr, const char* title);
+extern CPUProfile* CPUProfilerStopProfiling(CPUProfiler* ptr,
+                                            const char* title);
 extern void CPUProfileDelete(CPUProfile* ptr);
 
 extern ContextPtr NewContext(IsolatePtr iso_ptr,
@@ -143,7 +144,8 @@ extern void TemplateSetTemplate(TemplatePtr ptr,
 
 extern TemplatePtr NewObjectTemplate(IsolatePtr iso_ptr);
 extern RtnValue ObjectTemplateNewInstance(TemplatePtr ptr, ContextPtr ctx_ptr);
-extern void ObjectTemplateSetInternalFieldCount(TemplatePtr ptr, uint32_t field_count);
+extern void ObjectTemplateSetInternalFieldCount(TemplatePtr ptr,
+                                                uint32_t field_count);
 extern int ObjectTemplateInternalFieldCount(TemplatePtr ptr);
 
 extern TemplatePtr NewFunctionTemplate(IsolatePtr iso_ptr, int callback_ref);


### PR DESCRIPTION
## Problem

There were a couple of places where C++ `new` was used in v8go.cc, then C.free was used on that pointer in Go.  

Mixing these is technically undefined behaviour, even though `new` and `delete` is often implemented as a wrapper around `malloc` and `free`

## Solution

I used `malloc` to allocate these values so they can be safely freed using `C.free`.

Looks like clang-format was missed on the existing code in master, so using that produced some more noise to this change, but I isolated that to the second commit in this PR