### PR TITLE
Add the ThrowException fn to the isolate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Support for setting and getting internal fields for template object instances
 - Support for CPU profiling
 - Add V8 build for Apple Silicon
+- Add support for throwing an exception directly via the isolate's ThrowException function.
 
 ### Changed
 - Removed error return value from NewIsolate which never fails

--- a/isolate.go
+++ b/isolate.go
@@ -103,9 +103,10 @@ func (i *Isolate) Dispose() {
 	i.ptr = nil
 }
 
-// ThrowException will schedule for an exception to be thrown. This prevents
-// any JavaScript to be invoked and the caller must run immediately and the
-// JavaScript will only run after the exeption is handled.
+// ThrowException schedules an exception to be thrown when returning to
+// JavaScript. When an exception has been scheduled it is illegal to invoke
+// any JavaScript operation; the caller must return immediately and only after
+// the exception has been handled does it become legal to invoke JavaScript operations.
 func (i *Isolate) ThrowException(value *Value) *Value {
 	return &Value{
 		ptr: C.ThrowException(value.ptr),

--- a/isolate.go
+++ b/isolate.go
@@ -103,6 +103,13 @@ func (i *Isolate) Dispose() {
 	i.ptr = nil
 }
 
+// ThrowException will schedule for an exception to be thrown.
+func (i *Isolate) ThrowException(value *Value) *Value {
+	return &Value{
+		ptr: C.ThrowException(value.ptr),
+	}
+}
+
 // Deprecated: use `iso.Dispose()`.
 func (i *Isolate) Close() {
 	i.Dispose()

--- a/isolate.go
+++ b/isolate.go
@@ -109,7 +109,7 @@ func (i *Isolate) Dispose() {
 // the exception has been handled does it become legal to invoke JavaScript operations.
 func (i *Isolate) ThrowException(value *Value) *Value {
 	return &Value{
-		ptr: C.ThrowException(value.ptr),
+		ptr: C.IsolateThrowException(i.ptr, value.ptr),
 	}
 }
 

--- a/isolate.go
+++ b/isolate.go
@@ -103,7 +103,9 @@ func (i *Isolate) Dispose() {
 	i.ptr = nil
 }
 
-// ThrowException will schedule for an exception to be thrown.
+// ThrowException will schedule for an exception to be thrown. This prevents
+// any JavaScript to be invoked and the caller must run immediately and the
+// JavaScript will only run after the exeption is handled.
 func (i *Isolate) ThrowException(value *Value) *Value {
 	return &Value{
 		ptr: C.ThrowException(value.ptr),

--- a/isolate.go
+++ b/isolate.go
@@ -108,6 +108,9 @@ func (i *Isolate) Dispose() {
 // any JavaScript operation; the caller must return immediately and only after
 // the exception has been handled does it become legal to invoke JavaScript operations.
 func (i *Isolate) ThrowException(value *Value) *Value {
+	if i.ptr == nil {
+		panic("Isolate has been disposed")
+	}
 	return &Value{
 		ptr: C.IsolateThrowException(i.ptr, value.ptr),
 	}

--- a/isolate_test.go
+++ b/isolate_test.go
@@ -140,11 +140,7 @@ func TestIsolateThrowException(t *testing.T) {
 	iso := v8.NewIsolate()
 	defer iso.Dispose()
 
-	strErr, err := v8.NewValue(iso, "some type error")
-
-	if err != nil {
-		t.Errorf("unexpected error: %v", err)
-	}
+	strErr, _ := v8.NewValue(iso, "some type error")
 
 	throwError := func(val *v8.Value) {
 		v := iso.ThrowException(val)
@@ -164,13 +160,7 @@ func TestIsolateThrowException(t *testing.T) {
 
 	// Function that is passed a TypeError from JavaScript.
 	fn2 := v8.NewFunctionTemplate(iso, func(info *v8.FunctionCallbackInfo) *v8.Value {
-		args := info.Args()
-
-		if len(args) < 1 {
-			t.Error("expected a TypeError argument")
-		}
-
-		typeErr := args[0]
+		typeErr := info.Args()[0]
 
 		throwError(typeErr)
 
@@ -184,13 +174,13 @@ func TestIsolateThrowException(t *testing.T) {
 	ctx := v8.NewContext(iso, global)
 	defer ctx.Close()
 
-	_, e := ctx.RunScript("foo()", "forever.js")
+	_, e := ctx.RunScript("foo()", "foo.js")
 
 	if e.Error() != "some type error" {
 		t.Errorf("expected \"some type error\" error but got: %v", e)
 	}
 
-	_, e = ctx.RunScript("foo2(new TypeError('this is a test'))", "forever.js")
+	_, e = ctx.RunScript("foo2(new TypeError('this is a test'))", "foo.js")
 
 	if e.Error() != "TypeError: this is a test" {
 		t.Errorf("expected \"TypeError: this is a test\" error but got: %v", e)

--- a/isolate_test.go
+++ b/isolate_test.go
@@ -226,7 +226,6 @@ func TestIsolateGarbageCollection(t *testing.T) {
 func TestIsolateThrowException(t *testing.T) {
 	t.Parallel()
 	iso := v8.NewIsolate()
-	defer iso.Dispose()
 
 	strErr, _ := v8.NewValue(iso, "some type error")
 
@@ -260,7 +259,6 @@ func TestIsolateThrowException(t *testing.T) {
 	global.Set("foo2", fn2)
 
 	ctx := v8.NewContext(iso, global)
-	defer ctx.Close()
 
 	_, e := ctx.RunScript("foo()", "foo.js")
 
@@ -272,6 +270,12 @@ func TestIsolateThrowException(t *testing.T) {
 
 	if e.Error() != "TypeError: this is a test" {
 		t.Errorf("expected \"TypeError: this is a test\" error but got: %v", e)
+	}
+
+	ctx.Close()
+	iso.Dispose()
+	if recoverPanic(func() { iso.ThrowException(strErr) }) == nil {
+		t.Error("expected panic")
 	}
 }
 

--- a/isolate_test.go
+++ b/isolate_test.go
@@ -135,6 +135,68 @@ func TestIsolateGarbageCollection(t *testing.T) {
 	time.Sleep(time.Second)
 }
 
+func TestIsolateThrowException(t *testing.T) {
+	t.Parallel()
+	iso := v8.NewIsolate()
+	defer iso.Dispose()
+
+	strErr, err := v8.NewValue(iso, "some type error")
+
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+
+	throwError := func(val *v8.Value) {
+		v := iso.ThrowException(val)
+
+		if !v.IsNullOrUndefined() {
+			t.Error("expected result to be null or undefined")
+		}
+	}
+
+	// Function that throws a simple string error from within the function. It is meant
+	// to emulate when an error is returned within Go.
+	fn := v8.NewFunctionTemplate(iso, func(info *v8.FunctionCallbackInfo) *v8.Value {
+		throwError(strErr)
+
+		return nil
+	})
+
+	// Function that is passed a TypeError from JavaScript.
+	fn2 := v8.NewFunctionTemplate(iso, func(info *v8.FunctionCallbackInfo) *v8.Value {
+		args := info.Args()
+
+		if len(args) < 1 {
+			t.Error("expected a TypeError argument")
+		}
+
+		typeErr := args[0]
+
+		throwError(typeErr)
+
+		return nil
+	})
+
+	global := v8.NewObjectTemplate(iso)
+	global.Set("foo", fn)
+	global.Set("foo2", fn2)
+
+	ctx := v8.NewContext(iso, global)
+	defer ctx.Close()
+
+	_, e := ctx.RunScript("foo()", "forever.js")
+
+	if e.Error() != "some type error" {
+		t.Errorf("expected \"some type error\" error but got: %v", e)
+	}
+
+	_, e = ctx.RunScript("foo2(new TypeError('this is a test'))", "forever.js")
+
+	if e.Error() != "TypeError: this is a test" {
+		t.Errorf("expected \"TypeError: this is a test\" error but got: %v", e)
+	}
+}
+
 func BenchmarkIsolateInitialization(b *testing.B) {
 	b.ReportAllocs()
 	for n := 0; n < b.N; n++ {

--- a/v8go.cc
+++ b/v8go.cc
@@ -201,13 +201,8 @@ IsolateHStatistics IsolationGetHeapStatistics(IsolatePtr iso) {
 /********** Exceptions & Errors **********/
 
 ValuePtr IsolateThrowException(IsolatePtr iso, ValuePtr value) {
-  if (iso == nullptr) {
-    return nullptr;
-  }
-
-  m_ctx* ctx = value->ctx;
-
   ISOLATE_SCOPE(iso);
+  m_ctx* ctx = value->ctx;
 
   Local<Value> throw_ret_val = iso->ThrowException(value->ptr.Get(iso));
 

--- a/v8go.cc
+++ b/v8go.cc
@@ -198,6 +198,25 @@ IsolateHStatistics IsolationGetHeapStatistics(IsolatePtr iso) {
                             hs.number_of_detached_contexts()};
 }
 
+/********** Exceptions & Errors **********/
+
+ValuePtr ThrowException(ValuePtr value) {
+  Isolate* iso = value->iso;
+  m_ctx* ctx = value->ctx;
+
+  ISOLATE_SCOPE(iso);
+
+  Local<Value> throw_ret_val = iso->ThrowException(value->ptr.Get(iso));
+
+  m_value* new_val = new m_value;
+  new_val->iso = iso;
+  new_val->ctx = ctx;
+  new_val->ptr = Persistent<Value, CopyablePersistentTraits<Value>>(
+      iso, throw_ret_val);
+
+  return tracked_value(ctx, new_val);
+}
+
 /********** CpuProfiler **********/
 
 CPUProfiler* NewCPUProfiler(IsolatePtr iso_ptr) {

--- a/v8go.cc
+++ b/v8go.cc
@@ -200,8 +200,11 @@ IsolateHStatistics IsolationGetHeapStatistics(IsolatePtr iso) {
 
 /********** Exceptions & Errors **********/
 
-ValuePtr ThrowException(ValuePtr value) {
-  Isolate* iso = value->iso;
+ValuePtr IsolateThrowException(IsolatePtr iso, ValuePtr value) {
+  if (iso == nullptr) {
+    return nullptr;
+  }
+
   m_ctx* ctx = value->ctx;
 
   ISOLATE_SCOPE(iso);

--- a/v8go.h
+++ b/v8go.h
@@ -114,6 +114,8 @@ extern void IsolateTerminateExecution(IsolatePtr ptr);
 extern int IsolateIsExecutionTerminating(IsolatePtr ptr);
 extern IsolateHStatistics IsolationGetHeapStatistics(IsolatePtr ptr);
 
+extern ValuePtr ThrowException(ValuePtr value);
+
 extern CPUProfiler* NewCPUProfiler(IsolatePtr iso_ptr);
 extern void CPUProfilerDispose(CPUProfiler* ptr);
 extern void CPUProfilerStartProfiling(CPUProfiler* ptr, const char* title);

--- a/v8go.h
+++ b/v8go.h
@@ -114,7 +114,7 @@ extern void IsolateTerminateExecution(IsolatePtr ptr);
 extern int IsolateIsExecutionTerminating(IsolatePtr ptr);
 extern IsolateHStatistics IsolationGetHeapStatistics(IsolatePtr ptr);
 
-extern ValuePtr ThrowException(ValuePtr value);
+extern ValuePtr IsolateThrowException(IsolatePtr iso, ValuePtr value);
 
 extern CPUProfiler* NewCPUProfiler(IsolatePtr iso_ptr);
 extern void CPUProfilerDispose(CPUProfiler* ptr);


### PR DESCRIPTION
I've re-implemented the `ThrowException` function from #143, but added support for passing in a `Value` instead of just a string, as pointed out by @dylanahsmith. This allows us to pass a string, or forward in a `TypeError`.

A note: The return value is always `null` or `undefined`.