### PR TITLE
Fix several leaks in tests

### DIFF
--- a/context_test.go
+++ b/context_test.go
@@ -32,6 +32,7 @@ func TestContextExec(t *testing.T) {
 
 	iso := ctx.Isolate()
 	ctx2 := v8.NewContext(iso)
+	defer ctx2.Close()
 	_, err = ctx2.RunScript(`add`, "ctx2.js")
 	if err == nil {
 		t.Error("error expected but was <nil>")

--- a/function_template_test.go
+++ b/function_template_test.go
@@ -87,6 +87,7 @@ func TestFunctionCallbackInfoThis(t *testing.T) {
 	t.Parallel()
 
 	iso := v8.NewIsolate()
+	defer iso.Dispose()
 
 	foo := v8.NewObjectTemplate(iso)
 	foo.Set("name", "foobar")
@@ -102,6 +103,7 @@ func TestFunctionCallbackInfoThis(t *testing.T) {
 	global.Set("foo", foo)
 
 	ctx := v8.NewContext(iso, global)
+	defer ctx.Close()
 	ctx.RunScript("foo.bar()", "")
 
 	v, _ := this.Get("name")

--- a/function_test.go
+++ b/function_test.go
@@ -14,14 +14,14 @@ func TestFunctionCall(t *testing.T) {
 	t.Parallel()
 
 	ctx := v8.NewContext()
-	defer ctx.Isolate().Dispose()
+	iso := ctx.Isolate()
+	defer iso.Dispose()
 	defer ctx.Close()
 
 	_, err := ctx.RunScript("function add(a, b) { return a + b; }", "")
 	fatalIf(t, err)
 	addValue, err := ctx.Global().Get("add")
 	fatalIf(t, err)
-	iso := ctx.Isolate()
 
 	arg1, err := v8.NewValue(iso, int32(1))
 	fatalIf(t, err)
@@ -73,9 +73,11 @@ func TestFunctionCallWithObjectReceiver(t *testing.T) {
 	t.Parallel()
 
 	iso := v8.NewIsolate()
+	defer iso.Dispose()
 	global := v8.NewObjectTemplate(iso)
 
 	ctx := v8.NewContext(iso, global)
+	defer ctx.Close()
 	val, err := ctx.RunScript(`class Obj { constructor(input) { this.input = input } print() { return this.input.toString() } }; new Obj("some val")`, "")
 	fatalIf(t, err)
 	obj, err := val.AsObject()

--- a/isolate_test.go
+++ b/isolate_test.go
@@ -126,8 +126,9 @@ func TestIsolateGarbageCollection(t *testing.T) {
 
 	tmpl := v8.NewObjectTemplate(iso)
 	tmpl.Set("foo", "bar")
-	v8.NewContext(iso, tmpl)
+	ctx := v8.NewContext(iso, tmpl)
 
+	ctx.Close()
 	iso.Dispose()
 
 	runtime.GC()

--- a/object_test.go
+++ b/object_test.go
@@ -16,6 +16,8 @@ func TestObjectMethodCall(t *testing.T) {
 
 	ctx := v8.NewContext()
 	iso := ctx.Isolate()
+	defer iso.Dispose()
+	defer ctx.Close()
 	val, _ := ctx.RunScript(`class Obj { constructor(input) { this.input = input, this.prop = "" } print() { return this.input.toString() } }; new Obj("some val")`, "")
 	obj, _ := val.AsObject()
 	val, err := obj.MethodCall("print")


### PR DESCRIPTION
In order to address https://github.com/rogchap/v8go/issues/222, we need to avoid leaks in the tests as well as the code under test, since we currently depend on code using the library to dispose isolates and close contexts to avoid memory leaks.

This PR just adds the missing Isolate.Dispose and Context.Close calls that came up from using clang's address sanitizer.

