### PR TITLE
Add Leak Check workflow to CI that uses Leak Sanitizer

### DIFF
--- a/.github/workflows/leakcheck.yml
+++ b/.github/workflows/leakcheck.yml
@@ -1,0 +1,22 @@
+name: Leak Check
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: 1.17.2
+    - name: Checkout
+      uses: actions/checkout@v2
+    - name: Go Test
+      run: go test -v --tags leakcheck ./...

--- a/.github/workflows/leakcheck.yml
+++ b/.github/workflows/leakcheck.yml
@@ -19,4 +19,9 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v2
     - name: Go Test
-      run: go test -v --tags leakcheck ./...
+      env:
+        CC: clang
+        CXX: clang++
+      run: |
+        go test -c --tags leakcheck
+        ./v8go.test

--- a/README.md
+++ b/README.md
@@ -241,6 +241,26 @@ standard output being fully buffered.
 A simple way to avoid this problem is to flush the standard output stream after printing with the `fflush(stdout);` statement.
 Not relying on the flushing at exit can also help ensure the output is printed before a crash.
 
+### Local leak checking
+
+Leak checking is automatically done in CI, but it can be useful to do locally to debug leaks.
+
+The leakcheck build tag must be used to opt-n to leak checking. For instance, on Linux, the tests can be used as follows
+
+```
+go test --tags leakcheck
+```
+
+On macOS, leak checking isn't available with the version of clang that comes with Xcode, so a separate compiler installation
+is needed.  For example, with homebrew, `brew install llvm` will install a version of clang with support for this, which then
+ must be used by go using the CC and CXX environment variables. The ASAN_OPTIONS environment variable will also be needed to
+run the code with leak checking enabled, since it isn't enabled by default on macOS. E.g. with the homebrew installation of
+llvm, the tests can be run with
+
+```
+ASAN_OPTIONS=detect_leaks=1 CXX=/usr/local/opt/llvm/bin/clang++ CC=/usr/local/opt/llvm/bin/clang go test --tags leakcheck
+```
+
 ### Formatting
 
 Go has `go fmt`, C has `clang-format`. Any changes to the `v8go.h|cc` should be formated with `clang-format` with the

--- a/function_template_fetch_test.go
+++ b/function_template_fetch_test.go
@@ -1,0 +1,55 @@
+// Copyright 2021 Roger Chapman and the v8go contributors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// Ignore leaks within Go standard libraries http/https support code.
+// The getaddrinfo detected leaks can be avoided using GODEBUG=netdns=go but
+// currently there are more for loading system root certificates on macOS.
+//go:build !leakcheck || !darwin
+// +build !leakcheck !darwin
+
+package v8go_test
+
+import (
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"strings"
+
+	v8 "rogchap.com/v8go"
+)
+
+func ExampleFunctionTemplate_fetch() {
+	iso := v8.NewIsolate()
+	defer iso.Dispose()
+	global := v8.NewObjectTemplate(iso)
+
+	fetchfn := v8.NewFunctionTemplate(iso, func(info *v8.FunctionCallbackInfo) *v8.Value {
+		args := info.Args()
+		url := args[0].String()
+
+		resolver, _ := v8.NewPromiseResolver(info.Context())
+
+		go func() {
+			res, _ := http.Get(url)
+			body, _ := ioutil.ReadAll(res.Body)
+			val, _ := v8.NewValue(iso, string(body))
+			resolver.Resolve(val)
+		}()
+		return resolver.GetPromise().Value
+	})
+	global.Set("fetch", fetchfn, v8.ReadOnly)
+
+	ctx := v8.NewContext(iso, global)
+	defer ctx.Close()
+	val, _ := ctx.RunScript("fetch('https://rogchap.com/v8go')", "")
+	prom, _ := val.AsPromise()
+
+	// wait for the promise to resolve
+	for prom.State() == v8.Pending {
+		continue
+	}
+	fmt.Printf("%s\n", strings.Split(prom.Result().String(), "\n")[0])
+	// Output:
+	// <!DOCTYPE html>
+}

--- a/function_template_test.go
+++ b/function_template_test.go
@@ -6,9 +6,6 @@ package v8go_test
 
 import (
 	"fmt"
-	"io/ioutil"
-	"net/http"
-	"strings"
 	"testing"
 
 	v8 "rogchap.com/v8go"
@@ -126,39 +123,4 @@ func ExampleFunctionTemplate() {
 	ctx.RunScript("print('foo', 'bar', 0, 1)", "")
 	// Output:
 	// [foo bar 0 1]
-}
-
-func ExampleFunctionTemplate_fetch() {
-	iso := v8.NewIsolate()
-	defer iso.Dispose()
-	global := v8.NewObjectTemplate(iso)
-
-	fetchfn := v8.NewFunctionTemplate(iso, func(info *v8.FunctionCallbackInfo) *v8.Value {
-		args := info.Args()
-		url := args[0].String()
-
-		resolver, _ := v8.NewPromiseResolver(info.Context())
-
-		go func() {
-			res, _ := http.Get(url)
-			body, _ := ioutil.ReadAll(res.Body)
-			val, _ := v8.NewValue(iso, string(body))
-			resolver.Resolve(val)
-		}()
-		return resolver.GetPromise().Value
-	})
-	global.Set("fetch", fetchfn, v8.ReadOnly)
-
-	ctx := v8.NewContext(iso, global)
-	defer ctx.Close()
-	val, _ := ctx.RunScript("fetch('https://rogchap.com/v8go')", "")
-	prom, _ := val.AsPromise()
-
-	// wait for the promise to resolve
-	for prom.State() == v8.Pending {
-		continue
-	}
-	fmt.Printf("%s\n", strings.Split(prom.Result().String(), "\n")[0])
-	// Output:
-	// <!DOCTYPE html>
 }

--- a/leak_test.go
+++ b/leak_test.go
@@ -1,0 +1,21 @@
+// Copyright 2021 the v8go contributors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+//go:build leakcheck
+// +build leakcheck
+
+package v8go_test
+
+import (
+	"testing"
+	"os"
+
+	"rogchap.com/v8go"
+)
+
+func TestMain(m *testing.M) {
+	exitCode := m.Run()
+	v8go.DoLeakSanitizerCheck()
+	os.Exit(exitCode)
+}

--- a/leakcheck.go
+++ b/leakcheck.go
@@ -1,0 +1,23 @@
+// Copyright 2021 the v8go contributors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+//go:build leakcheck
+// +build leakcheck
+
+package v8go
+
+// #cgo CPPFLAGS: -fsanitize=address
+// #cgo LDFLAGS: -fsanitize=address
+//
+// #include <sanitizer/lsan_interface.h>
+import "C"
+
+import "runtime"
+
+// Call LLVM Leak Sanitizer's at-exit hook that doesn't
+// get called automatically by Go.
+func DoLeakSanitizerCheck() {
+	runtime.GC()
+	C.__lsan_do_leak_check()
+}


### PR DESCRIPTION
Fixes #222

I added a separate workflow that does leaking, since it seems redundant to do on multiple platforms or go versions.  It also seemed simpler than adding conditionals to fit it into the existing test workflow.

I've tried using this locally on Linux and MacOS and have added some README documentation for doing leak checking locally.  I haven't tested on windows, but it looks like it currently isn't supported on windows (https://clang.llvm.org/docs/LeakSanitizer.html#supported-platforms)