### PR TITLE
Compile with warnings and fix exiting warnings

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,6 +31,8 @@ jobs:
       run: echo "C:\msys64\mingw64\bin" >> $GITHUB_PATH
       shell: bash
     - name: Go Test
+      env:
+        CGO_CXXFLAGS: "-Werror"
       run: go test -v -coverprofile c.out ./...
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v1

--- a/cgo.go
+++ b/cgo.go
@@ -6,7 +6,7 @@ package v8go
 
 //go:generate clang-format -i --verbose -style=Chromium v8go.h v8go.cc
 
-// #cgo CXXFLAGS: -fno-rtti -fpic -std=c++14 -DV8_COMPRESS_POINTERS -DV8_31BIT_SMIS_ON_64BIT_ARCH -I${SRCDIR}/deps/include
+// #cgo CXXFLAGS: -fno-rtti -fpic -std=c++14 -DV8_COMPRESS_POINTERS -DV8_31BIT_SMIS_ON_64BIT_ARCH -I${SRCDIR}/deps/include -Wall
 // #cgo LDFLAGS: -pthread -lv8
 // #cgo darwin,amd64 LDFLAGS: -L${SRCDIR}/deps/darwin_x86_64
 // #cgo darwin,arm64 LDFLAGS: -L${SRCDIR}/deps/darwin_arm64

--- a/object.go
+++ b/object.go
@@ -93,7 +93,7 @@ func (o *Object) SetInternalField(idx uint32, val interface{}) error {
 		return err
 	}
 
-	inserted := C.ObjectSetInternalField(o.ptr, C.uint32_t(idx), value.ptr)
+	inserted := C.ObjectSetInternalField(o.ptr, C.int(idx), value.ptr)
 
 	if inserted == 0 {
 		panic(fmt.Errorf("index out of range [%v] with length %v", idx, o.InternalFieldCount()))
@@ -121,7 +121,7 @@ func (o *Object) Get(key string) (*Value, error) {
 // or the JS undefined value if the index hadn't been set.
 // Panics if given an out of range index.
 func (o *Object) GetInternalField(idx uint32) *Value {
-	rtn := C.ObjectGetInternalField(o.ptr, C.uint32_t(idx))
+	rtn := C.ObjectGetInternalField(o.ptr, C.int(idx))
 	if rtn == nil {
 		panic(fmt.Errorf("index out of range [%v] with length %v", idx, o.InternalFieldCount()))
 	}

--- a/object_template.go
+++ b/object_template.go
@@ -63,7 +63,7 @@ func (o *ObjectTemplate) NewInstance(ctx *Context) (*Object, error) {
 // SetInternalFieldCount sets the number of internal fields that instances of this
 // template will have.
 func (o *ObjectTemplate) SetInternalFieldCount(fieldCount uint32) {
-	C.ObjectTemplateSetInternalFieldCount(o.ptr, C.uint32_t(fieldCount))
+	C.ObjectTemplateSetInternalFieldCount(o.ptr, C.int(fieldCount))
 }
 
 // InternalFieldCount returns the number of internal fields that instances of this

--- a/v8go.cc
+++ b/v8go.cc
@@ -1465,7 +1465,6 @@ RtnValue FunctionNewInstance(ValuePtr ptr, int argc, ValuePtr args[]) {
 
 ValuePtr FunctionSourceMapUrl(ValuePtr ptr) {
   LOCAL_VALUE(ptr)
-  RtnValue rtn = {nullptr, nullptr};
   Local<Function> fn = Local<Function>::Cast(value);
   Local<Value> result = fn->GetScriptOrigin().SourceMapUrl();
   m_value* rtnval = new m_value;

--- a/v8go.cc
+++ b/v8go.cc
@@ -378,7 +378,7 @@ RtnValue ObjectTemplateNewInstance(TemplatePtr ptr, ContextPtr ctx) {
 }
 
 void ObjectTemplateSetInternalFieldCount(TemplatePtr ptr,
-                                         uint32_t field_count) {
+                                         int field_count) {
   LOCAL_TEMPLATE(ptr);
 
   Local<ObjectTemplate> obj_tmpl = tmpl.As<ObjectTemplate>();
@@ -1163,7 +1163,7 @@ void ObjectSetIdx(ValuePtr ptr, uint32_t idx, ValuePtr prop_val) {
   obj->Set(local_ctx, idx, prop_val->ptr.Get(iso)).Check();
 }
 
-int ObjectSetInternalField(ValuePtr ptr, uint32_t idx, ValuePtr val_ptr) {
+int ObjectSetInternalField(ValuePtr ptr, int idx, ValuePtr val_ptr) {
   LOCAL_OBJECT(ptr);
   m_value* prop_val = static_cast<m_value*>(val_ptr);
 
@@ -1206,7 +1206,7 @@ RtnValue ObjectGet(ValuePtr ptr, const char* key) {
   return rtn;
 }
 
-ValuePtr ObjectGetInternalField(ValuePtr ptr, uint32_t idx) {
+ValuePtr ObjectGetInternalField(ValuePtr ptr, int idx) {
   LOCAL_OBJECT(ptr);
 
   if (idx >= obj->InternalFieldCount()) {

--- a/v8go.cc
+++ b/v8go.cc
@@ -360,7 +360,7 @@ RtnValue ObjectTemplateNewInstance(TemplatePtr ptr, ContextPtr ctx) {
   Local<Context> local_ctx = ctx->ptr.Get(iso);
   Context::Scope context_scope(local_ctx);
 
-  RtnValue rtn = {nullptr, nullptr};
+  RtnValue rtn = {};
 
   Local<ObjectTemplate> obj_tmpl = tmpl.As<ObjectTemplate>();
   Local<Object> obj;
@@ -460,7 +460,7 @@ RtnValue FunctionTemplateGetFunction(TemplatePtr ptr, ContextPtr ctx) {
   Context::Scope context_scope(local_ctx);
 
   Local<FunctionTemplate> fn_tmpl = tmpl.As<FunctionTemplate>();
-  RtnValue rtn = {nullptr, nullptr};
+  RtnValue rtn = {};
   Local<Function> fn;
   if (!fn_tmpl->GetFunction(local_ctx).ToLocal(&fn)) {
     rtn.error = ExceptionError(try_catch, iso, local_ctx);
@@ -531,7 +531,7 @@ void ContextFree(ContextPtr ctx) {
 RtnValue RunScript(ContextPtr ctx, const char* source, const char* origin) {
   LOCAL_CONTEXT(ctx);
 
-  RtnValue rtn = {nullptr, nullptr};
+  RtnValue rtn = {};
 
   MaybeLocal<String> maybeSrc =
       String::NewFromUtf8(iso, source, NewStringType::kNormal);
@@ -565,7 +565,7 @@ RtnValue RunScript(ContextPtr ctx, const char* source, const char* origin) {
 
 RtnValue JSONParse(ContextPtr ctx, const char* str) {
   LOCAL_CONTEXT(ctx);
-  RtnValue rtn = {nullptr, nullptr};
+  RtnValue rtn = {};
 
   Local<String> v8Str;
   if (!String::NewFromUtf8(iso, str, NewStringType::kNormal).ToLocal(&v8Str)) {
@@ -679,7 +679,7 @@ ValuePtr NewValueIntegerFromUnsigned(IsolatePtr iso, uint32_t v) {
 RtnValue NewValueString(IsolatePtr iso, const char* v) {
   ISOLATE_SCOPE_INTERNAL_CONTEXT(iso);
   TryCatch try_catch(iso);
-  RtnValue rtn = {nullptr, nullptr};
+  RtnValue rtn = {};
   Local<String> str;
   if (!String::NewFromUtf8(iso, v).ToLocal(&str)) {
     rtn.error = ExceptionError(try_catch, iso, ctx->ptr.Get(iso));
@@ -760,7 +760,7 @@ RtnValue NewValueBigIntFromWords(IsolatePtr iso,
   TryCatch try_catch(iso);
   Local<Context> local_ctx = ctx->ptr.Get(iso);
 
-  RtnValue rtn = {nullptr, nullptr};
+  RtnValue rtn = {};
   Local<BigInt> bigint;
   if (!BigInt::NewFromWords(local_ctx, sign_bit, word_count, words)
            .ToLocal(&bigint)) {
@@ -809,7 +809,7 @@ double ValueToNumber(ValuePtr ptr) {
 
 RtnString ValueToDetailString(ValuePtr ptr) {
   LOCAL_VALUE(ptr);
-  RtnString rtn = {nullptr, nullptr};
+  RtnString rtn = {0};
   Local<String> str;
   if (!value->ToDetailString(local_ctx).ToLocal(&str)) {
     rtn.error = ExceptionError(try_catch, iso, local_ctx);
@@ -852,7 +852,7 @@ ValueBigInt ValueToBigInt(ValuePtr ptr) {
 
 RtnValue ValueToObject(ValuePtr ptr) {
   LOCAL_VALUE(ptr);
-  RtnValue rtn = {nullptr, nullptr};
+  RtnValue rtn = {};
   Local<Object> obj;
   if (!value->ToObject(local_ctx).ToLocal(&obj)) {
     rtn.error = ExceptionError(try_catch, iso, local_ctx);
@@ -1183,7 +1183,7 @@ int ObjectInternalFieldCount(ValuePtr ptr) {
 
 RtnValue ObjectGet(ValuePtr ptr, const char* key) {
   LOCAL_OBJECT(ptr);
-  RtnValue rtn = {nullptr, nullptr};
+  RtnValue rtn = {};
 
   Local<String> key_val;
   if (!String::NewFromUtf8(iso, key, NewStringType::kNormal)
@@ -1226,7 +1226,7 @@ ValuePtr ObjectGetInternalField(ValuePtr ptr, uint32_t idx) {
 
 RtnValue ObjectGetIdx(ValuePtr ptr, uint32_t idx) {
   LOCAL_OBJECT(ptr);
-  RtnValue rtn = {nullptr, nullptr};
+  RtnValue rtn = {};
 
   Local<Value> result;
   if (!obj->Get(local_ctx, idx).ToLocal(&result)) {
@@ -1271,7 +1271,7 @@ int ObjectDeleteIdx(ValuePtr ptr, uint32_t idx) {
 
 RtnValue NewPromiseResolver(ContextPtr ctx) {
   LOCAL_CONTEXT(ctx);
-  RtnValue rtn = {nullptr, nullptr};
+  RtnValue rtn = {};
   Local<Promise::Resolver> resolver;
   if (!Promise::Resolver::New(local_ctx).ToLocal(&resolver)) {
     rtn.error = ExceptionError(try_catch, iso, local_ctx);
@@ -1317,7 +1317,7 @@ int PromiseState(ValuePtr ptr) {
 
 RtnValue PromiseThen(ValuePtr ptr, int callback_ref) {
   LOCAL_VALUE(ptr)
-  RtnValue rtn = {nullptr, nullptr};
+  RtnValue rtn = {};
   Local<Promise> promise = value.As<Promise>();
   Local<Integer> cbData = Integer::New(iso, callback_ref);
   Local<Function> func;
@@ -1342,7 +1342,7 @@ RtnValue PromiseThen(ValuePtr ptr, int callback_ref) {
 
 RtnValue PromiseThen2(ValuePtr ptr, int on_fulfilled_ref, int on_rejected_ref) {
   LOCAL_VALUE(ptr)
-  RtnValue rtn = {nullptr, nullptr};
+  RtnValue rtn = {};
   Local<Promise> promise = value.As<Promise>();
   Local<Integer> onFulfilledData = Integer::New(iso, on_fulfilled_ref);
   Local<Function> onFulfilledFunc;
@@ -1375,7 +1375,7 @@ RtnValue PromiseThen2(ValuePtr ptr, int on_fulfilled_ref, int on_rejected_ref) {
 
 RtnValue PromiseCatch(ValuePtr ptr, int callback_ref) {
   LOCAL_VALUE(ptr)
-  RtnValue rtn = {nullptr, nullptr};
+  RtnValue rtn = {};
   Local<Promise> promise = value.As<Promise>();
   Local<Integer> cbData = Integer::New(iso, callback_ref);
   Local<Function> func;
@@ -1424,7 +1424,7 @@ static void buildCallArguments(Isolate* iso,
 RtnValue FunctionCall(ValuePtr ptr, ValuePtr recv, int argc, ValuePtr args[]) {
   LOCAL_VALUE(ptr)
 
-  RtnValue rtn = {nullptr, nullptr};
+  RtnValue rtn = {};
   Local<Function> fn = Local<Function>::Cast(value);
   Local<Value> argv[argc];
   buildCallArguments(iso, argv, argc, args);
@@ -1446,7 +1446,7 @@ RtnValue FunctionCall(ValuePtr ptr, ValuePtr recv, int argc, ValuePtr args[]) {
 
 RtnValue FunctionNewInstance(ValuePtr ptr, int argc, ValuePtr args[]) {
   LOCAL_VALUE(ptr)
-  RtnValue rtn = {nullptr, nullptr};
+  RtnValue rtn = {};
   Local<Function> fn = Local<Function>::Cast(value);
   Local<Value> argv[argc];
   buildCallArguments(iso, argv, argc, args);

--- a/v8go.h
+++ b/v8go.h
@@ -145,7 +145,7 @@ extern void TemplateSetTemplate(TemplatePtr ptr,
 extern TemplatePtr NewObjectTemplate(IsolatePtr iso_ptr);
 extern RtnValue ObjectTemplateNewInstance(TemplatePtr ptr, ContextPtr ctx_ptr);
 extern void ObjectTemplateSetInternalFieldCount(TemplatePtr ptr,
-                                                uint32_t field_count);
+                                                int field_count);
 extern int ObjectTemplateInternalFieldCount(TemplatePtr ptr);
 
 extern TemplatePtr NewFunctionTemplate(IsolatePtr iso_ptr, int callback_ref);
@@ -233,11 +233,11 @@ int ValueIsModuleNamespaceObject(ValuePtr ptr);
 
 extern void ObjectSet(ValuePtr ptr, const char* key, ValuePtr val_ptr);
 extern void ObjectSetIdx(ValuePtr ptr, uint32_t idx, ValuePtr val_ptr);
-extern int ObjectSetInternalField(ValuePtr ptr, uint32_t idx, ValuePtr val_ptr);
+extern int ObjectSetInternalField(ValuePtr ptr, int idx, ValuePtr val_ptr);
 extern int ObjectInternalFieldCount(ValuePtr ptr);
 extern RtnValue ObjectGet(ValuePtr ptr, const char* key);
 extern RtnValue ObjectGetIdx(ValuePtr ptr, uint32_t idx);
-extern ValuePtr ObjectGetInternalField(ValuePtr ptr, uint32_t idx);
+extern ValuePtr ObjectGetInternalField(ValuePtr ptr, int idx);
 int ObjectHas(ValuePtr ptr, const char* key);
 int ObjectHasIdx(ValuePtr ptr, uint32_t idx);
 int ObjectDelete(ValuePtr ptr, const char* key);


### PR DESCRIPTION
It is easy to make some stupid mistakes that wastes some time debugging when the compiler could have pointer out the problem.  Using `-Wall` (with gcc/clang) will enable warnings for errors that compilers can detect.

I've addressed the existing warnings in the first few commits.  I enabled compiler warnings by default when compiling locally.  Additionally, I used `-Werror` to treat warnings as errors in CI.

I chose not to treat warnings as errors locally, mostly because of experience with lint like errors interrupting the development/debug feedback loop when they aren't really relevant.  Although, this is kind of a philosophical divergence from Go (e.g. how it warns about unused imports when adding in import "fmt" for debugging), so I can enable `-Werror` locally if other v8go devs disagree.