### PR TITLE
Run v8 python script in a separate subshell

### DIFF
--- a/deps/build.py
+++ b/deps/build.py
@@ -105,9 +105,8 @@ def apply_patch(patch_name, working_dir):
     subprocess.check_call(["git", "apply", "-v", patch_path], cwd=working_dir)
 
 def update_last_change():
-    import v8.build.util.lastchange as lastchange
     out_path = os.path.join(v8_path, "build", "util", "LASTCHANGE")
-    lastchange.main(["lastchange", "-o", out_path])
+    subprocess.check_call(["python", "build/util/lastchange.py", "-o", out_path], cwd=v8_path)
 
 def main():
     v8deps()


### PR DESCRIPTION
## Problem

build/deps.py was trying to import a script from v8, in a way that isn't python3 compatible, since there aren't __init__.py files in the directories on the path to the script

## Solution

Use a separate command to execute the script, which is the way this is done in v8 as well (https://github.com/v8/v8/blob/ee74e718339223345b42935e9f4cbc7be208e557/DEPS#L552-L558).