### PR TITLE
Free memory on long lived isolates and contexts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Support for compiling a context-dependent UnboundScript which can be run in any context of the isolate it was compiled in.
 - Support for creating a code cache from an UnboundScript which can be used to create an UnboundScript in other isolates
 to run a pre-compiled script in new contexts.
+- Support for freeing isolates and contexts tracked values 
 
 ### Changed
 - Removed error return value from NewIsolate which never fails

--- a/context.go
+++ b/context.go
@@ -114,6 +114,12 @@ func (c *Context) PerformMicrotaskCheckpoint() {
 	C.IsolatePerformMicrotaskCheckpoint(c.iso.ptr)
 }
 
+// Cleanup will free the memory of tracked vals and unbound scripts.
+// It avoids leaking memory if the Context is long-lived and all scripts are stateless.
+func (c *Context) Cleanup() {
+	C.ContextCleanup(c.ptr)
+}
+
 // Close will dispose the context and free the memory.
 // Access to any values associated with the context after calling Close may panic.
 func (c *Context) Close() {

--- a/isolate.go
+++ b/isolate.go
@@ -149,6 +149,18 @@ func (i *Isolate) Dispose() {
 	i.ptr = nil
 }
 
+
+// Cleanup will free the memory of tracked values in the Isolate default context.
+// It avoids leaking memory if the Isolate is long-lived and all scripts are stateless.
+func (i *Isolate) Cleanup() {
+	if i.ptr == nil {
+		return
+	}
+	C.IsolateCleanup(i.ptr)
+	i.null = newValueNull(i)
+	i.undefined = newValueUndefined(i)
+}
+
 // ThrowException schedules an exception to be thrown when returning to
 // JavaScript. When an exception has been scheduled it is illegal to invoke
 // any JavaScript operation; the caller must return immediately and only after

--- a/v8go.cc
+++ b/v8go.cc
@@ -189,6 +189,13 @@ void IsolateDispose(IsolatePtr iso) {
   iso->Dispose();
 }
 
+void IsolateCleanup(IsolatePtr iso) {
+  if (iso == nullptr) {
+    return;
+  }
+  ContextCleanup(isolateInternalContext(iso));
+}
+
 void IsolateTerminateExecution(IsolatePtr iso) {
   iso->TerminateExecution();
 }
@@ -597,17 +604,23 @@ void ContextFree(ContextPtr ctx) {
   }
   ctx->ptr.Reset();
 
+  ContextCleanup(ctx);
+
+  delete ctx;
+}
+
+void ContextCleanup(ContextPtr ctx) {
   for (m_value* val : ctx->vals) {
     val->ptr.Reset();
     delete val;
   }
+  ctx->vals.clear();
 
   for (m_unboundScript* us : ctx->unboundScripts) {
     us->ptr.Reset();
     delete us;
   }
-
-  delete ctx;
+  ctx->unboundScripts.clear();
 }
 
 RtnValue RunScript(ContextPtr ctx, const char* source, const char* origin) {

--- a/v8go.h
+++ b/v8go.h
@@ -139,6 +139,7 @@ extern void Init();
 extern IsolatePtr NewIsolate();
 extern void IsolatePerformMicrotaskCheckpoint(IsolatePtr ptr);
 extern void IsolateDispose(IsolatePtr ptr);
+extern void IsolateCleanup(IsolatePtr iso);
 extern void IsolateTerminateExecution(IsolatePtr ptr);
 extern int IsolateIsExecutionTerminating(IsolatePtr ptr);
 extern IsolateHStatistics IsolationGetHeapStatistics(IsolatePtr ptr);
@@ -166,6 +167,7 @@ extern ContextPtr NewContext(IsolatePtr iso_ptr,
                              TemplatePtr global_template_ptr,
                              int ref);
 extern void ContextFree(ContextPtr ptr);
+extern void ContextCleanup(ContextPtr ctx);
 extern RtnValue RunScript(ContextPtr ctx_ptr,
                           const char* source,
                           const char* origin);


### PR DESCRIPTION
It is beneficial to create an isolate and a context only once and use them several times instead of recreating them each time. 

Creating an isolate and a context can take 3ms which is significant in some contexts (like a server that needs to execute a JS script on each incoming request).

The problem is that reusing the same isolate and context several times leads to memory leaks as all allocated values are freed only when the isolate and context are destroyed.

Therefore, it is necessary to free the memory from time to time to avoid leaks. Two functions were added Context.Cleanup() and Isolate.Cleanup().

Cleaning up Isolates and Contexts works only if executed scripts are stateless: they don't use global variables used between executions.

In this example, removing the call to Cleanup() will lead to a memory leak.

```
package main

import (
	"fmt"
	v8 "rogchap.com/v8go"
	"strings"
	"time"
)

func main() {

	// Create an isolate to compile scripts
	source := "console.log(getMsg());"                                              // This script is stateless
	iso1 := v8.NewIsolate()                                                         // Create a new JavaScript VM
	script1, _ := iso1.CompileUnboundScript(source, "test.js", v8.CompileOptions{}) // Compile script to get cached data
	cachedData := script1.CreateCodeCache()

	// Create an isolate to execute scripts
	iso2 := v8.NewIsolate()

	// Create a context with Go callbacks
	global := v8.NewObjectTemplate(iso2)
	_ = global.Set("getMsg", v8.NewFunctionTemplate(iso2, func(info *v8.FunctionCallbackInfo) *v8.Value {
		res, _ := v8.NewValue(iso2, "Hello World!\n")
		return res
	}))
	ctx2 := v8.NewContext(iso2, global)

	// Create a global object to output logs (console.log)
	console := v8.NewObjectTemplate(iso2)
	logfn := v8.NewFunctionTemplate(iso2, func(info *v8.FunctionCallbackInfo) *v8.Value {
		for _, v := range info.Args() {
			fmt.Printf(v.String())
		}
		return nil
	})
	_ = console.Set("log", logfn)
	_ = console.Set("error", logfn)

	for {
		// Reset the objects that have been freed
		consoleObj, _ := console.NewInstance(ctx2)
		_ = ctx2.Global().Set("console", consoleObj)

		// Compile script in new isolate with cached data
		compiledScript, _ := iso2.CompileUnboundScript(source, "test.js", v8.CompileOptions{CachedData: cachedData})
		_, err := compiledScript.Run(ctx2)
		if err != nil {
			panic(err)
		}

		// Cleanup context and isolate to free memory as the script is stateless (no global variables)
		ctx2.Cleanup()
		iso2.Cleanup()
	}
}
```