### PR TITLE
Remove useless print statement in a test

### DIFF
--- a/isolate_test.go
+++ b/isolate_test.go
@@ -209,7 +209,7 @@ func TestIsolateGarbageCollection(t *testing.T) {
 
 	iso := v8.NewIsolate()
 	val, _ := v8.NewValue(iso, "some string")
-	fmt.Println(val.String())
+	val.String()
 
 	tmpl := v8.NewObjectTemplate(iso)
 	tmpl.Set("foo", "bar")

--- a/isolate_test.go
+++ b/isolate_test.go
@@ -8,7 +8,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"math/rand"
-	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -202,25 +201,6 @@ func TestIsolateDispose(t *testing.T) {
 	if iso.GetHeapStatistics().TotalHeapSize != 0 {
 		t.Error("Isolate not disposed correctly")
 	}
-}
-
-func TestIsolateGarbageCollection(t *testing.T) {
-	t.Parallel()
-
-	iso := v8.NewIsolate()
-	val, _ := v8.NewValue(iso, "some string")
-	val.String()
-
-	tmpl := v8.NewObjectTemplate(iso)
-	tmpl.Set("foo", "bar")
-	ctx := v8.NewContext(iso, tmpl)
-
-	ctx.Close()
-	iso.Dispose()
-
-	runtime.GC()
-
-	time.Sleep(time.Second)
 }
 
 func TestIsolateThrowException(t *testing.T) {

--- a/object_template_test.go
+++ b/object_template_test.go
@@ -6,6 +6,7 @@ package v8go_test
 
 import (
 	"math/big"
+	"runtime"
 	"testing"
 
 	v8 "rogchap.com/v8go"
@@ -139,5 +140,19 @@ func TestObjectTemplateNewInstance(t *testing.T) {
 	if foo, _ := obj.Get("foo"); foo.String() != "bar" {
 		t.Errorf("unexpected value for object property: %v", foo)
 	}
+}
 
+func TestObjectTemplate_garbageCollection(t *testing.T) {
+	t.Parallel()
+
+	iso := v8.NewIsolate()
+
+	tmpl := v8.NewObjectTemplate(iso)
+	tmpl.Set("foo", "bar")
+	ctx := v8.NewContext(iso, tmpl)
+
+	ctx.Close()
+	iso.Dispose()
+
+	runtime.GC()
 }


### PR DESCRIPTION
I also changed the test since it was originally for isolate garbage collection, which is no longer done, but is still useful for template garbage collection that is still done.