### PR TITLE
CI: Run gofmt and clang-format automatically on pull requests

### DIFF
--- a/.github/workflows/fmt.yml
+++ b/.github/workflows/fmt.yml
@@ -1,0 +1,15 @@
+name: Format Code
+
+on: [pull_request, workflow_dispatch]
+
+jobs:
+    build:
+        runs-on: ubuntu-latest
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v2
+            - run: go fmt
+            - name: go generate (clang-format)
+              run: go generate
+            - name: Display missing format changes
+              run: git diff --exit-code

--- a/isolate_test.go
+++ b/isolate_test.go
@@ -132,7 +132,7 @@ func TestIsolateCompileUnboundScript_InvalidOptions(t *testing.T) {
 
 	opts := v8.CompileOptions{
 		CachedData: &v8.CompilerCachedData{Bytes: []byte("unused")},
-		Mode: v8.CompileModeEager,
+		Mode:       v8.CompileModeEager,
 	}
 	panicErr := recoverPanic(func() { iso.CompileUnboundScript("console.log(1)", "script.js", opts) })
 	if panicErr == nil {

--- a/leak_test.go
+++ b/leak_test.go
@@ -8,8 +8,8 @@
 package v8go_test
 
 import (
-	"testing"
 	"os"
+	"testing"
 
 	"rogchap.com/v8go"
 )

--- a/script_compiler.go
+++ b/script_compiler.go
@@ -11,7 +11,7 @@ type CompileMode C.int
 
 var (
 	CompileModeDefault = CompileMode(C.ScriptCompilerNoCompileOptions)
-	CompileModeEager = CompileMode(C.ScriptCompilerEagerCompile)
+	CompileModeEager   = CompileMode(C.ScriptCompilerEagerCompile)
 )
 
 type CompilerCachedData struct {

--- a/v8go.cc
+++ b/v8go.cc
@@ -217,7 +217,10 @@ IsolateHStatistics IsolationGetHeapStatistics(IsolatePtr iso) {
                             hs.number_of_detached_contexts()};
 }
 
-RtnUnboundScript IsolateCompileUnboundScript(IsolatePtr iso, const char* s, const char* o, CompileOptions opts) {
+RtnUnboundScript IsolateCompileUnboundScript(IsolatePtr iso,
+                                             const char* s,
+                                             const char* o,
+                                             CompileOptions opts) {
   ISOLATE_SCOPE_INTERNAL_CONTEXT(iso);
   TryCatch try_catch(iso);
   Local<Context> local_ctx = ctx->ptr.Get(iso);
@@ -230,12 +233,14 @@ RtnUnboundScript IsolateCompileUnboundScript(IsolatePtr iso, const char* s, cons
   Local<String> ogn =
       String::NewFromUtf8(iso, o, NewStringType::kNormal).ToLocalChecked();
 
-  ScriptCompiler::CompileOptions option = static_cast<ScriptCompiler::CompileOptions>(opts.compileOption);
+  ScriptCompiler::CompileOptions option =
+      static_cast<ScriptCompiler::CompileOptions>(opts.compileOption);
 
   ScriptCompiler::CachedData* cached_data = nullptr;
 
   if (opts.cachedData.data) {
-    cached_data = new ScriptCompiler::CachedData(opts.cachedData.data, opts.cachedData.length);
+    cached_data = new ScriptCompiler::CachedData(opts.cachedData.data,
+                                                 opts.cachedData.length);
   }
 
   ScriptOrigin script_origin(ogn);
@@ -243,7 +248,8 @@ RtnUnboundScript IsolateCompileUnboundScript(IsolatePtr iso, const char* s, cons
   ScriptCompiler::Source source(src, script_origin, cached_data);
 
   Local<UnboundScript> unbound_script;
-  if (!ScriptCompiler::CompileUnboundScript(iso, &source, option).ToLocal(&unbound_script)) {
+  if (!ScriptCompiler::CompileUnboundScript(iso, &source, option)
+           .ToLocal(&unbound_script)) {
     rtn.error = ExceptionError(try_catch, iso, local_ctx);
     return rtn;
   };
@@ -269,8 +275,8 @@ ValuePtr IsolateThrowException(IsolatePtr iso, ValuePtr value) {
   m_value* new_val = new m_value;
   new_val->iso = iso;
   new_val->ctx = ctx;
-  new_val->ptr = Persistent<Value, CopyablePersistentTraits<Value>>(
-      iso, throw_ret_val);
+  new_val->ptr =
+      Persistent<Value, CopyablePersistentTraits<Value>>(iso, throw_ret_val);
 
   return tracked_value(ctx, new_val);
 }
@@ -454,8 +460,7 @@ RtnValue ObjectTemplateNewInstance(TemplatePtr ptr, ContextPtr ctx) {
   return rtn;
 }
 
-void ObjectTemplateSetInternalFieldCount(TemplatePtr ptr,
-                                         int field_count) {
+void ObjectTemplateSetInternalFieldCount(TemplatePtr ptr, int field_count) {
   LOCAL_TEMPLATE(ptr);
 
   Local<ObjectTemplate> obj_tmpl = tmpl.As<ObjectTemplate>();
@@ -647,12 +652,15 @@ RtnValue RunScript(ContextPtr ctx, const char* source, const char* origin) {
 
 /********** UnboundScript & ScriptCompilerCachedData **********/
 
-ScriptCompilerCachedData* UnboundScriptCreateCodeCache(IsolatePtr iso, UnboundScriptPtr us_ptr) {
+ScriptCompilerCachedData* UnboundScriptCreateCodeCache(
+    IsolatePtr iso,
+    UnboundScriptPtr us_ptr) {
   ISOLATE_SCOPE(iso);
 
   Local<UnboundScript> unbound_script = us_ptr->ptr.Get(iso);
 
-  ScriptCompiler::CachedData* cached_data = ScriptCompiler::CreateCodeCache(unbound_script);
+  ScriptCompiler::CachedData* cached_data =
+      ScriptCompiler::CreateCodeCache(unbound_script);
 
   ScriptCompilerCachedData* cd = new ScriptCompilerCachedData;
   cd->ptr = cached_data;

--- a/v8go.h
+++ b/v8go.h
@@ -146,14 +146,15 @@ extern IsolateHStatistics IsolationGetHeapStatistics(IsolatePtr ptr);
 extern ValuePtr IsolateThrowException(IsolatePtr iso, ValuePtr value);
 
 extern RtnUnboundScript IsolateCompileUnboundScript(IsolatePtr iso_ptr,
-                                  const char* source,
-                                  const char* origin,
-                                  CompileOptions options);
-extern ScriptCompilerCachedData* UnboundScriptCreateCodeCache(IsolatePtr iso_ptr,
-                                                UnboundScriptPtr us_ptr);
-extern void ScriptCompilerCachedDataDelete(ScriptCompilerCachedData* cached_data);
-extern RtnValue UnboundScriptRun(ContextPtr ctx_ptr,
-                                 UnboundScriptPtr us_ptr);
+                                                    const char* source,
+                                                    const char* origin,
+                                                    CompileOptions options);
+extern ScriptCompilerCachedData* UnboundScriptCreateCodeCache(
+    IsolatePtr iso_ptr,
+    UnboundScriptPtr us_ptr);
+extern void ScriptCompilerCachedDataDelete(
+    ScriptCompilerCachedData* cached_data);
+extern RtnValue UnboundScriptRun(ContextPtr ctx_ptr, UnboundScriptPtr us_ptr);
 
 extern CPUProfiler* NewCPUProfiler(IsolatePtr iso_ptr);
 extern void CPUProfilerDispose(CPUProfiler* ptr);


### PR DESCRIPTION
## Problem

It is easy to forget to run `go fmt` or `go generate` to format the code.  This results in these changes ending up in following PRs and even get squashed into them due to the PRs being squash merged.

## Solution

Add a CI step that will fail if the code wasn't formatted and show the missing format changes.