### PR TITLE
Include compile error location in verbose error message format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Support for compiling a context-dependent UnboundScript which can be run in any context of the isolate it was compiled in.
 - Support for creating a code cache from an UnboundScript which can be used to create an UnboundScript in other isolates
 to run a pre-compiled script in new contexts.
+- Included compile error location in `%+v` formatting of JSError
 
 ### Changed
 - Removed error return value from NewIsolate which never fails

--- a/errors.go
+++ b/errors.go
@@ -44,7 +44,15 @@ func (e *JSError) Format(s fmt.State, verb rune) {
 	switch verb {
 	case 'v':
 		if s.Flag('+') && e.StackTrace != "" {
+			// The StackTrace starts with the Message, so only the former needs to be printed
 			io.WriteString(s, e.StackTrace)
+
+			// If it was a compile time error, then there wouldn't be a runtime stack trace,
+			// but StackTrace will still include the Message, making them equal. In this case,
+			// we want to include the Location where the compilation failed.
+			if e.StackTrace == e.Message && e.Location != "" {
+				fmt.Fprintf(s, " (at %s)", e.Location)
+			}
 			return
 		}
 		fallthrough


### PR DESCRIPTION
## Problem

I was debugging a syntax error and found that no location was being included when printing the JSError with `fmt.Printf("%+v\n", err)`, but that information was present in the struct's Location field.  It looks like this wasn't included in the StackTrace field that was used in JSError.Format, which may be because it isn't a runtime stack trace.

## Solution

Use `err.StackTrace == err.Message` to detect when there is no runtime stack trace, then add the err.Location if it is present.