### PR TITLE
CHANGELOG: Highlight the subtlety of the Function Call breaking change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,7 @@ to run a pre-compiled script in new contexts.
 - Removed error return value from NewContext which never fails
 - Removed error return value from Context.Isolate() which never fails
 - Removed error return value from NewObjectTemplate and NewFunctionTemplate. Panic if given a nil argument.
-- Function Call accepts receiver as first argument.
+- Function Call accepts receiver as first argument. This **subtle breaking change** will compile old code but interpret the first argument as the receiver. Use `Undefined` to prepend an argument to fix old Call use.
 - Removed Windows support until its build issues are addressed.
 - Upgrade to V8 9.6.180.12
 


### PR DESCRIPTION
## Problem

@newhook pointed out the problem on slack

> I just figured out another upgrade issue I ran into...
> ```
> func (fn *Function) Call(args ...Valuer) (*Value, error) {
> ```
> Changed to:
> ```
> func (fn *Function) Call(recv Valuer, args ...Valuer) (*Value, error) {
> ```
> That is a bit of subtle breaking change since the code continues to compile, it just doesn't work like at all. I wonder if the release notes could make that little more obvious?

## Solution

Add a couple more sentences to that changelog for that change to mention how old code will compile but the first argument would be reinterpreted and mention how to fix it.  Using the bold words **subtle breaking change** should help it stand out from other changes.