### PR TITLE
change -fpic to -fPIC in cgo.go

### DIFF
--- a/cgo.go
+++ b/cgo.go
@@ -6,7 +6,7 @@ package v8go
 
 //go:generate clang-format -i --verbose -style=Chromium v8go.h v8go.cc
 
-// #cgo CXXFLAGS: -fno-rtti -fpic -std=c++14 -DV8_COMPRESS_POINTERS -DV8_31BIT_SMIS_ON_64BIT_ARCH -I${SRCDIR}/deps/include -Wall
+// #cgo CXXFLAGS: -fno-rtti -fPIC -std=c++14 -DV8_COMPRESS_POINTERS -DV8_31BIT_SMIS_ON_64BIT_ARCH -I${SRCDIR}/deps/include -Wall
 // #cgo LDFLAGS: -pthread -lv8
 // #cgo darwin,amd64 LDFLAGS: -L${SRCDIR}/deps/darwin_x86_64
 // #cgo darwin,arm64 LDFLAGS: -L${SRCDIR}/deps/darwin_arm64


### PR DESCRIPTION
on darwin/x86_64 to compile linux/arm64 will be failed if "CXXFLAGS: ... -fpic ...", change the flag to "-fPIC" solved the problem.