### PR TITLE
make sure sure to free the array buffer allocator when calling Isolate Dispose

### DIFF
--- a/v8go.cc
+++ b/v8go.cc
@@ -185,8 +185,8 @@ void IsolateDispose(IsolatePtr iso) {
     return;
   }
   ContextFree(isolateInternalContext(iso));
-
   iso->Dispose();
+  delete iso->GetArrayBufferAllocator();
 }
 
 void IsolateTerminateExecution(IsolatePtr iso) {


### PR DESCRIPTION
I was looking at some of the examples files from the v8 API reference and by the looks of it it looks like that they are freeing the array buffer allocator.

https://v8.github.io/api/head/shell_8cc-example.html#a13

I checked and looks like we are not doing that on our end. I added a simple call to `delete iso->GetArrayBufferAllocator();` when we are disposing of the isolate.

