### PR TITLE
Remove unnecessary nested Locker and Isolate::Scope use

### DIFF
--- a/v8go.cc
+++ b/v8go.cc
@@ -62,8 +62,6 @@ const char* CopyString(String::Utf8Value& value) {
 }
 
 RtnError ExceptionError(TryCatch& try_catch, Isolate* iso, Local<Context> ctx) {
-  Locker locker(iso);
-  Isolate::Scope isolate_scope(iso);
   HandleScope handle_scope(iso);
 
   RtnError rtn = {nullptr, nullptr, nullptr};

--- a/v8go.cc
+++ b/v8go.cc
@@ -61,7 +61,9 @@ const char* CopyString(String::Utf8Value& value) {
   return CopyString(*value);
 }
 
-RtnError ExceptionError(TryCatch& try_catch, Isolate* iso, Local<Context> ctx) {
+static RtnError ExceptionError(TryCatch& try_catch,
+                               Isolate* iso,
+                               Local<Context> ctx) {
   HandleScope handle_scope(iso);
 
   RtnError rtn = {nullptr, nullptr, nullptr};


### PR DESCRIPTION
cc @GustavoCaso 

While reviewing https://github.com/Shopify/v8go/pull/39, I noticed that ExceptionError used

```
  Locker locker(iso);
  Isolate::Scope isolate_scope(iso);
```

even though ExceptionError isn't exported to Go code and the caller should already have taken the lock and entered that isolate scope.  That PR was trying to preserve this behaviour for existing code, but we should actually just remove those lines.

I've also made ExceptionError static, making it clearer that it isn't used outside that c file.