### PR TITLE
Add String type, constructor functions for it and Value.AsString to cast to it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Add String type, constructor functions for it and Value.AsString() to cast to it
+
 ### Fixed
 - Use string length to ensure null character-containing strings in Go/JS are not terminated early.
 - Object.Set with an empty key string is now supported

--- a/context_test.go
+++ b/context_test.go
@@ -123,9 +123,7 @@ func TestRegistryFromJSON(t *testing.T) {
 
 	global := v8.NewObjectTemplate(iso)
 	err := global.Set("location", v8.NewFunctionTemplate(iso, func(info *v8.FunctionCallbackInfo) *v8.Value {
-		v, err := v8.NewValue(iso, "world")
-		fatalIf(t, err)
-		return v
+		return v8.MustNewString(iso, "world").Value
 	}))
 	fatalIf(t, err)
 

--- a/function_template_fetch_test.go
+++ b/function_template_fetch_test.go
@@ -33,7 +33,7 @@ func ExampleFunctionTemplate_fetch() {
 		go func() {
 			res, _ := http.Get(url)
 			body, _ := ioutil.ReadAll(res.Body)
-			val, _ := v8.NewValue(iso, string(body))
+			val := v8.MustNewString(iso, string(body))
 			resolver.Resolve(val)
 		}()
 		return resolver.GetPromise().Value

--- a/function_template_test.go
+++ b/function_template_test.go
@@ -60,8 +60,8 @@ func TestFunctionTemplateGetFunction(t *testing.T) {
 	var args *v8.FunctionCallbackInfo
 	tmpl := v8.NewFunctionTemplate(iso, func(info *v8.FunctionCallbackInfo) *v8.Value {
 		args = info
-		reply, _ := v8.NewValue(iso, "hello")
-		return reply
+		reply := v8.MustNewString(iso, "hello")
+		return reply.Value
 	})
 	fn := tmpl.GetFunction(ctx)
 	ten, err := v8.NewValue(iso, int32(10))

--- a/function_test.go
+++ b/function_test.go
@@ -162,8 +162,7 @@ func TestFunctionNewInstance(t *testing.T) {
 	fatalIf(t, err)
 	fn, err := value.AsFunction()
 	fatalIf(t, err)
-	messageObj, err := v8.NewValue(iso, "test message")
-	fatalIf(t, err)
+	messageObj := v8.MustNewString(iso, "test message")
 	errObj, err := fn.NewInstance(messageObj)
 	fatalIf(t, err)
 

--- a/isolate_test.go
+++ b/isolate_test.go
@@ -203,7 +203,7 @@ func TestIsolateThrowException(t *testing.T) {
 	t.Parallel()
 	iso := v8.NewIsolate()
 
-	strErr, _ := v8.NewValue(iso, "some type error")
+	strErr := v8.MustNewString(iso, "some type error").Value
 
 	throwError := func(val *v8.Value) {
 		v := iso.ThrowException(val)

--- a/object_template_test.go
+++ b/object_template_test.go
@@ -24,7 +24,7 @@ func TestObjectTemplate(t *testing.T) {
 		}
 	}
 
-	val, _ := v8.NewValue(iso, "bar")
+	val := v8.MustNewString(iso, "bar").Value
 	objVal := v8.NewObjectTemplate(iso)
 	bigbigint, _ := new(big.Int).SetString("36893488147419099136", 10) // larger than a single word size (64bit)
 	bigbignegint, _ := new(big.Int).SetString("-36893488147419099136", 10)

--- a/object_test.go
+++ b/object_test.go
@@ -33,7 +33,7 @@ func TestObjectMethodCall(t *testing.T) {
 	val, err = ctx.RunScript(`class Obj2 { print(str) { return str.toString() }; get fails() { throw "error" } }; new Obj2()`, "")
 	fatalIf(t, err)
 	obj, _ = val.AsObject()
-	arg, _ := v8.NewValue(iso, "arg")
+	arg := v8.MustNewString(iso, "arg")
 	val, err = obj.MethodCall("print", arg)
 	fatalIf(t, err)
 	if val.String() != "arg" {

--- a/promise_test.go
+++ b/promise_test.go
@@ -41,7 +41,7 @@ func TestPromiseFulfilled(t *testing.T) {
 		t.Error("unexpected call of Then prior to resolving the promise")
 	}
 
-	val1, _ := v8.NewValue(iso, "foo")
+	val1 := v8.MustNewString(iso, "foo")
 	res1.Resolve(val1)
 
 	if s := prom1.State(); s != v8.Fulfilled {
@@ -69,8 +69,8 @@ func TestPromiseRejected(t *testing.T) {
 	defer ctx.Close()
 
 	res2, _ := v8.NewPromiseResolver(ctx)
-	val2, _ := v8.NewValue(iso, "Bad Foo")
-	res2.Reject(val2)
+	val2 := v8.MustNewString(iso, "Bad Foo")
+	res2.Reject(val2.Value)
 
 	prom2 := res2.GetPromise()
 	if s := prom2.State(); s != v8.Rejected {

--- a/string.go
+++ b/string.go
@@ -1,0 +1,45 @@
+// Copyright 2022 the v8go contributors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package v8go
+
+// #include <stdlib.h>
+// #include "v8go.h"
+import "C"
+import (
+	"unsafe"
+)
+
+// String is a JavaScript string object (ECMA-262, 4.3.17)
+type String struct {
+	*Value
+}
+
+func jsStringResult(ctx *Context, rtn C.RtnValue) (String, error) {
+	if rtn.value == nil {
+		return String{nil}, newJSError(rtn.error)
+	}
+	return String{&Value{rtn.value, ctx}}, nil
+}
+
+// NewString returns a JS string from the Go string or an error if the string is longer than the max V8 string length.
+func NewString(iso *Isolate, val string) (String, error) {
+	cstr := C.CString(val)
+	defer C.free(unsafe.Pointer(cstr))
+	rtn := C.NewValueString(iso.ptr, cstr, C.int(len(val)))
+	return jsStringResult(nil, rtn)
+}
+
+// MustNewString wraps NewString with a panic on error check.
+//
+// Use for strings known to be within than the max V8 string length.
+// V8's max string length is (1 << 28) - 16 on 32-bit systems
+// and (1 << 29) - 24 on other systems, at the time of writing.
+func MustNewString(iso *Isolate, val string) String {
+	jsStr, err := NewString(iso, val)
+	if err != nil {
+		panic(err)
+	}
+	return jsStr
+}

--- a/value.go
+++ b/value.go
@@ -70,10 +70,8 @@ func NewValue(iso *Isolate, val interface{}) (*Value, error) {
 
 	switch v := val.(type) {
 	case string:
-		cstr := C.CString(v)
-		defer C.free(unsafe.Pointer(cstr))
-		rtn := C.NewValueString(iso.ptr, cstr, C.int(len(v)))
-		return valueResult(nil, rtn)
+		str, err := NewString(iso, v)
+		return str.Value, err
 	case int32:
 		rtnVal = &Value{
 			ptr: C.NewValueInteger(iso.ptr, C.int(v)),
@@ -565,6 +563,13 @@ func (v *Value) AsFunction() (*Function, error) {
 		return nil, errors.New("v8go: value is not a Function")
 	}
 	return &Function{v}, nil
+}
+
+func (v *Value) AsString() (*String, error) {
+	if !v.IsFunction() {
+		return nil, errors.New("v8go: value is not a String")
+	}
+	return &String{v}, nil
 }
 
 // MarshalJSON implements the json.Marshaler interface.


### PR DESCRIPTION
## Problem

https://github.com/rogchap/v8go/pull/266 is attempting to add a constructor function for a V8 string, but we don't yet have a v8go.String type for it to return.  It is also adding a constructor function with a NewString prefix for the edge case of binary strings, but there isn't yet a NewString function for the normal case.  These seem like short-sighted API design decisions that are biased by what is currently available.

## Solution

Add a String type, so that it can be used in APIs to better match the V8 APIs.  We can latter extend this with v8::String methods, but this will still inherit all the Value methods through the embedded Value field.

The NewString function was added to use instead of NewValue, since individual constructors provide better type safety and are more in line with V8's API.

The MustNewString was added as a convenience method for constructing a V8 string from a Go literal string, where we know the function won't fail.

Value.AsString was also added for converting a Value to a String.