### PR TITLE
Expose HitCount and HitLineCount to CPUProfileNode

### DIFF
--- a/cpuprofilenode.go
+++ b/cpuprofilenode.go
@@ -17,6 +17,12 @@ type CPUProfileNode struct {
 	// The number of the column where the function originates.
 	columnNumber int
 
+	// The number of samples recorded in the function
+	hitCount uint
+
+	// The number of lines in which samples were recorded in the function
+	hitLineCount uint
+
 	// The children node of this node.
 	children []*CPUProfileNode
 
@@ -42,6 +48,16 @@ func (c *CPUProfileNode) GetLineNumber() int {
 // Returns number of the column where the function originates.
 func (c *CPUProfileNode) GetColumnNumber() int {
 	return c.columnNumber
+}
+
+// Returns total samples recorded inside the function
+func (c *CPUProfileNode) GetHitCount() uint {
+	return c.hitCount
+}
+
+// Returns total number of lines inside the function recording samples
+func (c *CPUProfileNode) GetHitLineCount() uint {
+	return c.hitLineCount
 }
 
 // Retrieves the ancestor node, or nil if the root.

--- a/cpuprofiler.go
+++ b/cpuprofiler.go
@@ -79,6 +79,8 @@ func newCPUProfileNode(node *C.CPUProfileNode, parent *CPUProfileNode) *CPUProfi
 		functionName:       C.GoString(node.functionName),
 		lineNumber:         int(node.lineNumber),
 		columnNumber:       int(node.columnNumber),
+		hitCount:           uint(node.hitCount),
+		hitLineCount:       uint(node.hitLineCount),
 		parent:             parent,
 	}
 

--- a/v8go.cc
+++ b/v8go.cc
@@ -332,6 +332,8 @@ CPUProfileNode* NewCPUProfileNode(const CpuProfileNode* ptr_) {
       ptr_->GetFunctionNameStr(),
       ptr_->GetLineNumber(),
       ptr_->GetColumnNumber(),
+      ptr_->GetHitCount(),
+      ptr_->GetHitLineCount(),
       count,
       children,
   };

--- a/v8go.h
+++ b/v8go.h
@@ -88,6 +88,8 @@ typedef struct CPUProfileNode {
   const char* functionName;
   int lineNumber;
   int columnNumber;
+  unsigned int hitCount;
+  unsigned int hitLineCount;
   int childrenCount;
   struct CPUProfileNode** children;
 } CPUProfileNode;


### PR DESCRIPTION
This exposes hitCount and hitLineCount from v8's cpuprofile node. It's useful in order to be able to see relative percentages of time spent in a v8 function and its descendants, although computing total time is left up to the presentation implementation.

Sample implementation:

```go
func printTree(nest string, node *v8.CPUProfileNode) {
	file, name, line, col := node.GetScriptResourceName(), node.GetFunctionName(), node.GetLineNumber(), node.GetColumnNumber()
	selfHits, totalHits := node.GetHitCount(), totalHitCountForNode(node)

	fmt.Printf("[%d/%d hits\t]  %s%s() %s:%d:%d\n", selfHits, totalHits, nest, name, file, line, col)

	count := node.GetChildrenCount()
	if count == 0 {
		return
	}

	nest = fmt.Sprintf("%s  ", nest)

	for i := 0; i < count; i++ {
		printTree(nest, node.GetChild(i))
	}
}

func totalHitCountForNode(node *v8.CPUProfileNode) uint {
	totalHitCount := node.GetHitCount()

	count := node.GetChildrenCount()
	for i := 0; i < count; i++ {
		totalHitCount += totalHitCountForNode(node.GetChild(i))
	}

	return totalHitCount
}
```