### PR TITLE
Fix typo in promise.go

### DIFF
--- a/promise.go
+++ b/promise.go
@@ -33,7 +33,7 @@ type Promise struct {
 	*Object
 }
 
-// MewPromiseResolver creates a new Promise resolver for the given context.
+// NewPromiseResolver creates a new Promise resolver for the given context.
 // The associated Promise will be in a Pending state.
 func NewPromiseResolver(ctx *Context) (*PromiseResolver, error) {
 	if ctx == nil {


### PR DESCRIPTION
Literally just fixing a typo in `promise.go` that I discovered while strolling through the code.