### PR TITLE
Reduce frequency for automatic opening of V8 upgrade PRs

### DIFF
--- a/.github/workflows/v8upgrade.yml
+++ b/.github/workflows/v8upgrade.yml
@@ -3,7 +3,7 @@ name: V8 Upgrade
 on:
   workflow_dispatch:
   schedule:
-    - cron: '0 0 * * *' # Run every day
+    - cron: '0 0 1 * *' # Run every day
 
 jobs:
     upgrade:


### PR DESCRIPTION
## Problem

I noticed that there were 11 open "Upgrade V8 binaries" PRs which had been automatically opened and had been sitting for over a month.

## Solution

Reduce the frequency for automatically opening these PRs to once a month rather than once a day.  We can always increase or decrease the frequency going forward, but this seems like it would be closer to the current frequency that V8 is bumped in practice.