### PR TITLE
Updating context documentation

### DIFF
--- a/context.go
+++ b/context.go
@@ -76,8 +76,7 @@ func NewContext(opt ...ContextOption) *Context {
 	return ctx
 }
 
-// Isolate gets the current context's parent isolate.An  error is returned
-// if the isolate has been terninated.
+// Isolate gets the current context's parent isolate.
 func (c *Context) Isolate() *Isolate {
 	return c.iso
 }


### PR DESCRIPTION
The documentation on `Context.Isolate()` still referenced returning an `error`, which is no longer the case. This PR cleans that up.