### PR TITLE
Add additional CPUProfile values

### DIFF
--- a/cpuprofilenode.go
+++ b/cpuprofilenode.go
@@ -5,6 +5,12 @@
 package v8go
 
 type CPUProfileNode struct {
+	// The id of the current node, unique within the tree.
+	nodeId int
+
+	// The id of the script where the function originates.
+	scriptId int
+
 	// The resource name for script from where the function originates.
 	scriptResourceName string
 
@@ -17,11 +23,27 @@ type CPUProfileNode struct {
 	// The number of the column where the function originates.
 	columnNumber int
 
+	// The count of samples where the function was currently executing.
+	hitCount int
+
+	// The bailout reason for the function if the optimization was disabled for it.
+	bailoutReason string
+
 	// The children node of this node.
 	children []*CPUProfileNode
 
 	// The parent node of this node.
 	parent *CPUProfileNode
+}
+
+// Returns node id.
+func (c *CPUProfileNode) GetNodeId() int {
+	return c.nodeId
+}
+
+// Returns id for script from where the function originates.
+func (c *CPUProfileNode) GetScriptId() int {
+	return c.scriptId
 }
 
 // Returns function name (empty string for anonymous functions.)
@@ -42,6 +64,16 @@ func (c *CPUProfileNode) GetLineNumber() int {
 // Returns number of the column where the function originates.
 func (c *CPUProfileNode) GetColumnNumber() int {
 	return c.columnNumber
+}
+
+// Returns count of samples where the function was currently executing.
+func (c *CPUProfileNode) GetHitCount() int {
+	return c.hitCount
+}
+
+// Returns the bailout reason for the function if the optimization was disabled for it.
+func (c *CPUProfileNode) GetBailoutReason() string {
+	return c.bailoutReason
 }
 
 // Retrieves the ancestor node, or nil if the root.

--- a/cpuprofiler.go
+++ b/cpuprofiler.go
@@ -75,10 +75,14 @@ func (c *CPUProfiler) StopProfiling(title string) *CPUProfile {
 
 func newCPUProfileNode(node *C.CPUProfileNode, parent *CPUProfileNode) *CPUProfileNode {
 	n := &CPUProfileNode{
+		nodeId:             int(node.nodeId),
+		scriptId:           int(node.scriptId),
 		scriptResourceName: C.GoString(node.scriptResourceName),
 		functionName:       C.GoString(node.functionName),
 		lineNumber:         int(node.lineNumber),
 		columnNumber:       int(node.columnNumber),
+		hitCount:           int(node.hitCount),
+		bailoutReason:      C.GoString(node.bailoutReason),
 		parent:             parent,
 	}
 

--- a/v8go.cc
+++ b/v8go.cc
@@ -328,10 +328,14 @@ CPUProfileNode* NewCPUProfileNode(const CpuProfileNode* ptr_) {
 
   CPUProfileNode* root = new CPUProfileNode{
       ptr_,
+      ptr_->GetNodeId(),
+      ptr_->GetScriptId(),
       ptr_->GetScriptResourceNameStr(),
       ptr_->GetFunctionNameStr(),
       ptr_->GetLineNumber(),
       ptr_->GetColumnNumber(),
+      ptr_->GetHitCount(),
+      ptr_->GetBailoutReason(),
       count,
       children,
   };

--- a/v8go.h
+++ b/v8go.h
@@ -84,10 +84,14 @@ typedef struct {
 
 typedef struct CPUProfileNode {
   CpuProfileNodePtr ptr;
+  unsigned nodeId;
+  int scriptId;
   const char* scriptResourceName;
   const char* functionName;
   int lineNumber;
   int columnNumber;
+  unsigned hitCount;
+  const char* bailoutReason;
   int childrenCount;
   struct CPUProfileNode** children;
 } CPUProfileNode;


### PR DESCRIPTION
Re: #283 

This PR adds the following additional values from [CPUProfileNode](https://v8docs.nodesource.com/node-16.15/d9/d6e/classv8_1_1_cpu_profile_node.html):
- [NodeId](https://v8docs.nodesource.com/node-16.15/d9/d6e/classv8_1_1_cpu_profile_node.html#a8ce3cb0b67b25227e68ef93944985fb7)
- [ScriptId](https://v8docs.nodesource.com/node-16.15/d9/d6e/classv8_1_1_cpu_profile_node.html#ac9332ecaea2232bdead05901522edc9d)
- [HitCount](https://v8docs.nodesource.com/node-16.15/d9/d6e/classv8_1_1_cpu_profile_node.html#afc9e7236aea6ea8e597016a74ce87eb6)
- [BailoutReason](https://v8docs.nodesource.com/node-16.15/d9/d6e/classv8_1_1_cpu_profile_node.html#ac562b6b67298941d139cd81dc2903d59)

Note: Since the ID's and hit counts are dynamic, I wasn't able to write tests around them. Let me know if anyone has suggestions on a consistent approach there.