### PR TITLE
v8.Value becomes manually releaseable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Added support for Value.release() and FunctionCallbackInfo.release(). This is useful when using v8go in a long-running context.
+
 ### Fixed
 - Use string length to ensure null character-containing strings in Go/JS are not terminated early.
 - Object.Set with an empty key string is now supported

--- a/context.go
+++ b/context.go
@@ -81,6 +81,12 @@ func (c *Context) Isolate() *Isolate {
 	return c.iso
 }
 
+func (c *Context) RetainedValueCount() int {
+	ctxMutex.Lock()
+	defer ctxMutex.Unlock()
+	return int(C.ContextRetainedValueCount(c.ptr))
+}
+
 // RunScript executes the source JavaScript; origin (a.k.a. filename) provides a
 // reference for the script and used in the stack trace if there is an error.
 // error will be of type `JSError` if not nil.

--- a/context_test.go
+++ b/context_test.go
@@ -104,8 +104,8 @@ func TestMemoryLeak(t *testing.T) {
 
 	for i := 0; i < 6000; i++ {
 		ctx := v8.NewContext(iso)
-		obj := ctx.Global()
-		_ = obj.String()
+		_ = ctx.Global()
+		// _ = obj.String()
 		_, _ = ctx.RunScript("2", "")
 		ctx.Close()
 	}

--- a/function_template.go
+++ b/function_template.go
@@ -37,6 +37,13 @@ func (i *FunctionCallbackInfo) Args() []*Value {
 	return i.args
 }
 
+func (i *FunctionCallbackInfo) Release() {
+	for _, arg := range i.args {
+		arg.Release()
+	}
+	i.this.Release()
+}
+
 // FunctionTemplate is used to create functions at runtime.
 // There can only be one function created from a FunctionTemplate in a context.
 // The lifetime of the created function is equal to the lifetime of the context.

--- a/function_template_test.go
+++ b/function_template_test.go
@@ -48,6 +48,44 @@ func TestFunctionTemplate_panic_on_nil_callback(t *testing.T) {
 	defer iso.Dispose()
 	v8.NewFunctionTemplate(iso, nil)
 }
+func TestFunctionTemplate_generates_values(t *testing.T) {
+	t.Parallel()
+
+	iso := v8.NewIsolate()
+	defer iso.Dispose()
+	global := v8.NewObjectTemplate(iso)
+	printfn := v8.NewFunctionTemplate(iso, func(info *v8.FunctionCallbackInfo) *v8.Value {
+		fmt.Printf("%+v\n", info.Args())
+		return nil
+	})
+	global.Set("print", printfn, v8.ReadOnly)
+	ctx := v8.NewContext(iso, global)
+	defer ctx.Close()
+	ctx.RunScript("print('foo', 'bar', 0, 1)", "")
+	if ctx.RetainedValueCount() != 5 {
+		t.Errorf("expected 5 retained values, got: %d", ctx.RetainedValueCount())
+	}
+}
+
+func TestFunctionTemplate_releases_values(t *testing.T) {
+	t.Parallel()
+
+	iso := v8.NewIsolate()
+	defer iso.Dispose()
+	global := v8.NewObjectTemplate(iso)
+	printfn := v8.NewFunctionTemplate(iso, func(info *v8.FunctionCallbackInfo) *v8.Value {
+		defer info.Release()
+		fmt.Printf("%+v\n", info.Args())
+		return nil
+	})
+	global.Set("print", printfn, v8.ReadOnly)
+	ctx := v8.NewContext(iso, global)
+	defer ctx.Close()
+	ctx.RunScript("print('foo', 'bar', 0, 1)", "")
+	if ctx.RetainedValueCount() != 0 {
+		t.Errorf("expected 0 retained values, got: %d", ctx.RetainedValueCount())
+	}
+}
 
 func TestFunctionTemplateGetFunction(t *testing.T) {
 	t.Parallel()

--- a/function_template_test.go
+++ b/function_template_test.go
@@ -62,8 +62,8 @@ func TestFunctionTemplate_generates_values(t *testing.T) {
 	ctx := v8.NewContext(iso, global)
 	defer ctx.Close()
 	ctx.RunScript("print('foo', 'bar', 0, 1)", "")
-	if ctx.RetainedValueCount() != 5 {
-		t.Errorf("expected 5 retained values, got: %d", ctx.RetainedValueCount())
+	if ctx.RetainedValueCount() != 6 {
+		t.Errorf("expected 6 retained values, got: %d", ctx.RetainedValueCount())
 	}
 }
 
@@ -82,8 +82,9 @@ func TestFunctionTemplate_releases_values(t *testing.T) {
 	ctx := v8.NewContext(iso, global)
 	defer ctx.Close()
 	ctx.RunScript("print('foo', 'bar', 0, 1)", "")
-	if ctx.RetainedValueCount() != 0 {
-		t.Errorf("expected 0 retained values, got: %d", ctx.RetainedValueCount())
+	// there is a constant factor associated with the global.
+	if ctx.RetainedValueCount() != 1 {
+		t.Errorf("expected 1 retained values, got: %d", ctx.RetainedValueCount())
 	}
 }
 

--- a/v8go.cc
+++ b/v8go.cc
@@ -616,8 +616,9 @@ void ContextFree(ContextPtr ctx) {
   }
   ctx->ptr.Reset();
 
-  
-  for(auto& [key, value] : ctx->vals) {
+  for (auto it = ctx->vals.begin(); it != ctx->vals.end(); ++it) {
+    auto key = it->first;
+    auto value = it->second;
     value->ptr.Reset();
     delete value;
   }

--- a/v8go.cc
+++ b/v8go.cc
@@ -109,21 +109,9 @@ static RtnError ExceptionError(TryCatch& try_catch,
 m_value* tracked_value(m_ctx* ctx, m_value* val) {
   // (rogchap) we track values against a context so that when the context is
   // closed (either manually or GC'd by Go) we can also release all the
-  // values associated with the context; previously the Go GC would not run
-  // quickly enough, as it has no understanding of the C memory allocation size.
-  // By doing so we hold pointers to all values that are created/returned to Go
-  // until the context is released; this is a compromise.
-  // Ideally we would be able to delete the value object and cancel the
-  // finalizer on the Go side, but we currently don't pass the Go ptr, but
-  // rather the C ptr. A potential future iteration would be to use an
-  // unordered_map, where we could do O(1) lookups for the value, but then know
-  // if the object has been finalized or not by being in the map or not. This
-  // would require some ref id for the value rather than passing the ptr between
-  // Go <--> C, which would be a significant change, as there are places where
-  // we get the context from the value, but if we then need the context to get
-  // the value, we would be in a circular bind.
+  // values associated with the context; 
   if (val->id == 0) {
-    val->id = ctx->nextValId++;
+    val->id = ++ctx->nextValId;
     ctx->vals[val->id] = val;
   }
 
@@ -279,6 +267,7 @@ ValuePtr IsolateThrowException(IsolatePtr iso, ValuePtr value) {
   Local<Value> throw_ret_val = iso->ThrowException(value->ptr.Get(iso));
 
   m_value* new_val = new m_value;
+  new_val->id = 0;
   new_val->iso = iso;
   new_val->ctx = ctx;
   new_val->ptr =
@@ -463,6 +452,7 @@ RtnValue ObjectTemplateNewInstance(TemplatePtr ptr, ContextPtr ctx) {
   }
 
   m_value* val = new m_value;
+  val->id = 0;
   val->iso = iso;
   val->ctx = ctx;
   val->ptr = Persistent<Value, CopyablePersistentTraits<Value>>(iso, obj);
@@ -500,6 +490,7 @@ static void FunctionTemplateCallback(const FunctionCallbackInfo<Value>& info) {
   int callback_ref = info.Data().As<Integer>()->Value();
 
   m_value* _this = new m_value;
+  _this->id = 0;
   _this->iso = iso;
   _this->ctx = ctx;
   _this->ptr.Reset(iso, Persistent<Value, CopyablePersistentTraits<Value>>(
@@ -511,6 +502,7 @@ static void FunctionTemplateCallback(const FunctionCallbackInfo<Value>& info) {
   ValuePtr* args = thisAndArgs + 1;
   for (int i = 0; i < args_count; i++) {
     m_value* val = new m_value;
+    val->id = 0;
     val->iso = iso;
     val->ctx = ctx;
     val->ptr.Reset(
@@ -560,6 +552,7 @@ RtnValue FunctionTemplateGetFunction(TemplatePtr ptr, ContextPtr ctx) {
   }
 
   m_value* val = new m_value;
+  val->id = 0;
   val->iso = iso;
   val->ctx = ctx;
   val->ptr = Persistent<Value, CopyablePersistentTraits<Value>>(iso, fn);
@@ -619,7 +612,7 @@ void ContextFree(ContextPtr ctx) {
   for (auto it = ctx->vals.begin(); it != ctx->vals.end(); ++it) {
     auto value = it->second;
     value->ptr.Reset();
-    delete value;
+    // delete value;
   }
   ctx->vals.clear();
 
@@ -658,6 +651,7 @@ RtnValue RunScript(ContextPtr ctx, const char* source, const char* origin) {
     return rtn;
   }
   m_value* val = new m_value;
+  val->id = 0;
   val->iso = iso;
   val->ctx = ctx;
   val->ptr = Persistent<Value, CopyablePersistentTraits<Value>>(iso, result);
@@ -707,6 +701,7 @@ RtnValue UnboundScriptRun(ContextPtr ctx, UnboundScriptPtr us_ptr) {
     return rtn;
   }
   m_value* val = new m_value;
+  val->id = 0;
   val->iso = iso;
   val->ctx = ctx;
   val->ptr = Persistent<Value, CopyablePersistentTraits<Value>>(iso, result);
@@ -730,6 +725,7 @@ RtnValue JSONParse(ContextPtr ctx, const char* str) {
     return rtn;
   }
   m_value* val = new m_value;
+  val->id = 0;
   val->iso = iso;
   val->ctx = ctx;
   val->ptr = Persistent<Value, CopyablePersistentTraits<Value>>(iso, result);
@@ -787,6 +783,7 @@ void ValueRelease(ValuePtr ptr) {
 ValuePtr ContextGlobal(ContextPtr ctx) {
   LOCAL_CONTEXT(ctx);
   m_value* val = new m_value;
+  val->id = 0;
 
   val->iso = iso;
   val->ctx = ctx;
@@ -818,6 +815,7 @@ ValuePtr ContextGlobal(ContextPtr ctx) {
 ValuePtr NewValueInteger(IsolatePtr iso, int32_t v) {
   ISOLATE_SCOPE_INTERNAL_CONTEXT(iso);
   m_value* val = new m_value;
+  val->id = 0;
   val->iso = iso;
   val->ctx = ctx;
   val->ptr = Persistent<Value, CopyablePersistentTraits<Value>>(
@@ -828,6 +826,7 @@ ValuePtr NewValueInteger(IsolatePtr iso, int32_t v) {
 ValuePtr NewValueIntegerFromUnsigned(IsolatePtr iso, uint32_t v) {
   ISOLATE_SCOPE_INTERNAL_CONTEXT(iso);
   m_value* val = new m_value;
+  val->id = 0;
   val->iso = iso;
   val->ctx = ctx;
   val->ptr = Persistent<Value, CopyablePersistentTraits<Value>>(
@@ -846,6 +845,7 @@ RtnValue NewValueString(IsolatePtr iso, const char* v, int v_length) {
     return rtn;
   }
   m_value* val = new m_value;
+  val->id = 0;
   val->iso = iso;
   val->ctx = ctx;
   val->ptr = Persistent<Value, CopyablePersistentTraits<Value>>(iso, str);
@@ -856,6 +856,7 @@ RtnValue NewValueString(IsolatePtr iso, const char* v, int v_length) {
 ValuePtr NewValueNull(IsolatePtr iso) {
   ISOLATE_SCOPE_INTERNAL_CONTEXT(iso);
   m_value* val = new m_value;
+  val->id = 0;
   val->iso = iso;
   val->ctx = ctx;
   val->ptr = Persistent<Value, CopyablePersistentTraits<Value>>(iso, Null(iso));
@@ -865,6 +866,7 @@ ValuePtr NewValueNull(IsolatePtr iso) {
 ValuePtr NewValueUndefined(IsolatePtr iso) {
   ISOLATE_SCOPE_INTERNAL_CONTEXT(iso);
   m_value* val = new m_value;
+  val->id = 0;
   val->iso = iso;
   val->ctx = ctx;
   val->ptr =
@@ -875,6 +877,7 @@ ValuePtr NewValueUndefined(IsolatePtr iso) {
 ValuePtr NewValueBoolean(IsolatePtr iso, int v) {
   ISOLATE_SCOPE_INTERNAL_CONTEXT(iso);
   m_value* val = new m_value;
+  val->id = 0;
   val->iso = iso;
   val->ctx = ctx;
   val->ptr = Persistent<Value, CopyablePersistentTraits<Value>>(
@@ -885,6 +888,7 @@ ValuePtr NewValueBoolean(IsolatePtr iso, int v) {
 ValuePtr NewValueNumber(IsolatePtr iso, double v) {
   ISOLATE_SCOPE_INTERNAL_CONTEXT(iso);
   m_value* val = new m_value;
+  val->id = 0;
   val->iso = iso;
   val->ctx = ctx;
   val->ptr = Persistent<Value, CopyablePersistentTraits<Value>>(
@@ -895,6 +899,7 @@ ValuePtr NewValueNumber(IsolatePtr iso, double v) {
 ValuePtr NewValueBigInt(IsolatePtr iso, int64_t v) {
   ISOLATE_SCOPE_INTERNAL_CONTEXT(iso);
   m_value* val = new m_value;
+  val->id = 0;
   val->iso = iso;
   val->ctx = ctx;
   val->ptr = Persistent<Value, CopyablePersistentTraits<Value>>(
@@ -905,6 +910,7 @@ ValuePtr NewValueBigInt(IsolatePtr iso, int64_t v) {
 ValuePtr NewValueBigIntFromUnsigned(IsolatePtr iso, uint64_t v) {
   ISOLATE_SCOPE_INTERNAL_CONTEXT(iso);
   m_value* val = new m_value;
+  val->id = 0;
   val->iso = iso;
   val->ctx = ctx;
   val->ptr = Persistent<Value, CopyablePersistentTraits<Value>>(
@@ -928,6 +934,7 @@ RtnValue NewValueBigIntFromWords(IsolatePtr iso,
     return rtn;
   }
   m_value* val = new m_value;
+  val->id = 0;
   val->iso = iso;
   val->ctx = ctx;
   val->ptr = Persistent<Value, CopyablePersistentTraits<Value>>(iso, bigint);
@@ -1025,6 +1032,7 @@ RtnValue ValueToObject(ValuePtr ptr) {
     return rtn;
   }
   m_value* new_val = new m_value;
+  new_val->id = 0;
   new_val->iso = iso;
   new_val->ctx = ctx;
   new_val->ptr = Persistent<Value, CopyablePersistentTraits<Value>>(iso, obj);
@@ -1363,6 +1371,7 @@ RtnValue ObjectGet(ValuePtr ptr, const char* key) {
     return rtn;
   }
   m_value* new_val = new m_value;
+  new_val->id = 0;
   new_val->iso = iso;
   new_val->ctx = ctx;
   new_val->ptr =
@@ -1382,6 +1391,7 @@ ValuePtr ObjectGetInternalField(ValuePtr ptr, int idx) {
   Local<Value> result = obj->GetInternalField(idx);
 
   m_value* new_val = new m_value;
+  new_val->id = 0;
   new_val->iso = iso;
   new_val->ctx = ctx;
   new_val->ptr =
@@ -1400,6 +1410,7 @@ RtnValue ObjectGetIdx(ValuePtr ptr, uint32_t idx) {
     return rtn;
   }
   m_value* new_val = new m_value;
+  new_val->id = 0;
   new_val->iso = iso;
   new_val->ctx = ctx;
   new_val->ptr =
@@ -1444,6 +1455,7 @@ RtnValue NewPromiseResolver(ContextPtr ctx) {
     return rtn;
   }
   m_value* val = new m_value;
+  val->id = 0;
   val->iso = iso;
   val->ctx = ctx;
   val->ptr = Persistent<Value, CopyablePersistentTraits<Value>>(iso, resolver);
@@ -1456,6 +1468,7 @@ ValuePtr PromiseResolverGetPromise(ValuePtr ptr) {
   Local<Promise::Resolver> resolver = value.As<Promise::Resolver>();
   Local<Promise> promise = resolver->GetPromise();
   m_value* promise_val = new m_value;
+  promise_val->id = 0;
   promise_val->iso = iso;
   promise_val->ctx = ctx;
   promise_val->ptr =
@@ -1498,6 +1511,7 @@ RtnValue PromiseThen(ValuePtr ptr, int callback_ref) {
     return rtn;
   }
   m_value* result_val = new m_value;
+  result_val->id = 0;
   result_val->iso = iso;
   result_val->ctx = ctx;
   result_val->ptr =
@@ -1531,6 +1545,7 @@ RtnValue PromiseThen2(ValuePtr ptr, int on_fulfilled_ref, int on_rejected_ref) {
     return rtn;
   }
   m_value* result_val = new m_value;
+  result_val->id = 0;
   result_val->iso = iso;
   result_val->ctx = ctx;
   result_val->ptr =
@@ -1556,6 +1571,7 @@ RtnValue PromiseCatch(ValuePtr ptr, int callback_ref) {
     return rtn;
   }
   m_value* result_val = new m_value;
+  result_val->id = 0;
   result_val->iso = iso;
   result_val->ctx = ctx;
   result_val->ptr =
@@ -1569,6 +1585,7 @@ ValuePtr PromiseResult(ValuePtr ptr) {
   Local<Promise> promise = value.As<Promise>();
   Local<Value> result = promise->Result();
   m_value* result_val = new m_value;
+  result_val->id = 0;
   result_val->iso = iso;
   result_val->ctx = ctx;
   result_val->ptr =
@@ -1603,6 +1620,7 @@ RtnValue FunctionCall(ValuePtr ptr, ValuePtr recv, int argc, ValuePtr args[]) {
     return rtn;
   }
   m_value* rtnval = new m_value;
+  rtnval->id = 0;
   rtnval->iso = iso;
   rtnval->ctx = ctx;
   rtnval->ptr = Persistent<Value, CopyablePersistentTraits<Value>>(iso, result);
@@ -1622,6 +1640,7 @@ RtnValue FunctionNewInstance(ValuePtr ptr, int argc, ValuePtr args[]) {
     return rtn;
   }
   m_value* rtnval = new m_value;
+  rtnval->id = 0;
   rtnval->iso = iso;
   rtnval->ctx = ctx;
   rtnval->ptr = Persistent<Value, CopyablePersistentTraits<Value>>(iso, result);
@@ -1634,6 +1653,7 @@ ValuePtr FunctionSourceMapUrl(ValuePtr ptr) {
   Local<Function> fn = Local<Function>::Cast(value);
   Local<Value> result = fn->GetScriptOrigin().SourceMapUrl();
   m_value* rtnval = new m_value;
+  rtnval->id = 0;
   rtnval->iso = iso;
   rtnval->ctx = ctx;
   rtnval->ptr = Persistent<Value, CopyablePersistentTraits<Value>>(iso, result);

--- a/v8go.cc
+++ b/v8go.cc
@@ -617,7 +617,6 @@ void ContextFree(ContextPtr ctx) {
   ctx->ptr.Reset();
 
   for (auto it = ctx->vals.begin(); it != ctx->vals.end(); ++it) {
-    auto key = it->first;
     auto value = it->second;
     value->ptr.Reset();
     delete value;

--- a/v8go.cc
+++ b/v8go.cc
@@ -612,7 +612,7 @@ void ContextFree(ContextPtr ctx) {
   for (auto it = ctx->vals.begin(); it != ctx->vals.end(); ++it) {
     auto value = it->second;
     value->ptr.Reset();
-    // delete value;
+    delete value;
   }
   ctx->vals.clear();
 

--- a/v8go.cc
+++ b/v8go.cc
@@ -11,8 +11,8 @@
 #include <iostream>
 #include <sstream>
 #include <string>
-#include <vector>
 #include <unordered_map>
+#include <vector>
 
 #include "_cgo_export.h"
 
@@ -109,7 +109,7 @@ static RtnError ExceptionError(TryCatch& try_catch,
 m_value* tracked_value(m_ctx* ctx, m_value* val) {
   // (rogchap) we track values against a context so that when the context is
   // closed (either manually or GC'd by Go) we can also release all the
-  // values associated with the context; 
+  // values associated with the context;
   if (val->id == 0) {
     val->id = ++ctx->nextValId;
     ctx->vals[val->id] = val;
@@ -769,12 +769,11 @@ const char* JSONStringify(ContextPtr ctx, ValuePtr val) {
   return CopyString(json);
 }
 
-
 void ValueRelease(ValuePtr ptr) {
   if (ptr == nullptr) {
     return;
   }
-  
+
   ptr->ctx->vals.erase(ptr->id);
   ptr->ptr.Reset();
   delete ptr;

--- a/v8go.h
+++ b/v8go.h
@@ -166,6 +166,7 @@ extern void CPUProfileDelete(CPUProfile* ptr);
 extern ContextPtr NewContext(IsolatePtr iso_ptr,
                              TemplatePtr global_template_ptr,
                              int ref);
+extern int ContextRetainedValueCount(ContextPtr ctx);
 extern void ContextFree(ContextPtr ptr);
 extern RtnValue RunScript(ContextPtr ctx_ptr,
                           const char* source,
@@ -207,6 +208,7 @@ extern RtnValue NewValueBigIntFromWords(IsolatePtr iso_ptr,
                                         int sign_bit,
                                         int word_count,
                                         const uint64_t* words);
+void ValueRelease(ValuePtr ptr);
 extern RtnString ValueToString(ValuePtr ptr);
 const uint32_t* ValueToArrayIndex(ValuePtr ptr);
 int ValueToBoolean(ValuePtr ptr);

--- a/value.go
+++ b/value.go
@@ -531,6 +531,11 @@ func (v *Value) IsProxy() bool {
 	return C.ValueIsProxy(v.ptr) != 0
 }
 
+// Release this value.  Using the value after calling this function will result in undefined behavior.
+func (v *Value) Release() {
+	C.ValueRelease(v.ptr)
+}
+
 // IsWasmModuleObject returns true if this value is a `WasmModuleObject`.
 func (v *Value) IsWasmModuleObject() bool {
 	// TODO(rogchap): requires test case


### PR DESCRIPTION
This allows long-lived contexts that call go functions without leaking memory.  Typically, you'd want to use the following pattern for go functions that don't allow values to escape.

	printfn := v8.NewFunctionTemplate(iso, func(info *v8.FunctionCallbackInfo) *v8.Value {
		defer info.Release()
		fmt.Printf("%+v\n", info.Args())
		return nil
	})