### PR TITLE
[Heap Profiler] Heap snapshots in v8go

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Added support for Value.release() and FunctionCallbackInfo.release(). This is useful when using v8go in a long-running context.
+- Support for Heap Snapshots
 
 ### Fixed
 - Use string length to ensure null character-containing strings in Go/JS are not terminated early.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Added support for Value.release() and FunctionCallbackInfo.release(). This is useful when using v8go in a long-running context.
-- Support for Heap Snapshots
 
 ### Fixed
 - Use string length to ensure null character-containing strings in Go/JS are not terminated early.

--- a/README.md
+++ b/README.md
@@ -181,6 +181,27 @@ func printTree(nest string, node *v8.CPUProfileNode) {
 //   (garbage collector) :0:0
 ```
 
+### Heap Snapshots
+
+```go
+func createHeapSnapshot() {
+	iso := v8.NewIsolate()
+	heapProfiler := v8.NewHeapProfiler(iso)
+	defer iso.Dispose()
+	printfn := v8.NewFunctionTemplate(iso, func(info *v8.FunctionCallbackInfo) *v8.Value {
+		fmt.Printf("%v", info.Args())
+		return nil
+	})
+	global := v8.NewObjectTemplate(iso)
+	global.Set("print", printfn)
+	ctx := v8.NewContext(iso, global)
+	ctx.RunScript("print('foo')", "print.js")
+
+    // This snapshot can be loaded in Chrome dev tools in memory tab
+	str, err := heapProfiler.TakeHeapSnapshot()
+    ioutil.WriteFile("isolate.heapsnapshot", []byte(str), 0755)
+}
+```
 ## Documentation
 
 Go Reference & more examples: https://pkg.go.dev/rogchap.com/v8go

--- a/README.md
+++ b/README.md
@@ -197,7 +197,7 @@ func createHeapSnapshot() {
 	ctx := v8.NewContext(iso, global)
 	ctx.RunScript("print('foo')", "print.js")
 
-	// This snapshot can be loaded in Chrome dev tools in memory tab
+	// This snapshot can be loaded in Chrome dev tools for debugging and inspection
 	str, err := heapProfiler.TakeHeapSnapshot()
 	ioutil.WriteFile("isolate.heapsnapshot", []byte(str), 0755)
 }

--- a/README.md
+++ b/README.md
@@ -197,9 +197,9 @@ func createHeapSnapshot() {
 	ctx := v8.NewContext(iso, global)
 	ctx.RunScript("print('foo')", "print.js")
 
-    // This snapshot can be loaded in Chrome dev tools in memory tab
+	// This snapshot can be loaded in Chrome dev tools in memory tab
 	str, err := heapProfiler.TakeHeapSnapshot()
-    ioutil.WriteFile("isolate.heapsnapshot", []byte(str), 0755)
+	ioutil.WriteFile("isolate.heapsnapshot", []byte(str), 0755)
 }
 ```
 ## Documentation

--- a/heap_profiler.go
+++ b/heap_profiler.go
@@ -1,0 +1,31 @@
+package v8go
+
+/*
+#include <stdlib.h>
+#include "v8go.h"
+*/
+import "C"
+import "unsafe"
+
+type HeapProfiler struct {
+	p   *C.V8HeapProfiler
+	iso *Isolate
+}
+
+func NewHeapProfiler(iso *Isolate) *HeapProfiler {
+	profiler := C.NewHeapProfiler(iso.ptr)
+	return &HeapProfiler{
+		p:   profiler,
+		iso: iso,
+	}
+}
+
+func (c *HeapProfiler) TakeHeapSnapshot() (string, error) {
+	if c.p == nil || c.iso.ptr == nil {
+		panic("heap profiler or isolate is nil")
+	}
+
+	str := C.TakeHeapSnapshot(c.p)
+	defer C.free(unsafe.Pointer(str))
+	return C.GoString(str), nil
+}

--- a/heap_profiler_test.go
+++ b/heap_profiler_test.go
@@ -1,0 +1,35 @@
+package v8go_test
+
+import (
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	v8 "rogchap.com/v8go"
+)
+
+func TestHeapSnapshot(t *testing.T) {
+	t.Parallel()
+	iso := v8.NewIsolate()
+	heapProfiler := v8.NewHeapProfiler(iso)
+	defer iso.Dispose()
+	printfn := v8.NewFunctionTemplate(iso, func(info *v8.FunctionCallbackInfo) *v8.Value {
+		fmt.Printf("%v", info.Args())
+		return nil
+	})
+	global := v8.NewObjectTemplate(iso)
+	global.Set("print", printfn)
+	ctx := v8.NewContext(iso, global)
+	ctx.RunScript("print('foo')", "print.js")
+
+	str, err := heapProfiler.TakeHeapSnapshot()
+	if err != nil {
+		t.Errorf("expected nil but got error: %v", err)
+	}
+
+	var snapshot map[string]interface{}
+	err = json.Unmarshal([]byte(str), &snapshot)
+	if err != nil {
+		t.Fatal(err)
+	}
+}

--- a/v8go.cc
+++ b/v8go.cc
@@ -278,6 +278,70 @@ ValuePtr IsolateThrowException(IsolatePtr iso, ValuePtr value) {
   return tracked_value(ctx, new_val);
 }
 
+/********** HeapProfiler **********/
+
+V8HeapProfiler* NewHeapProfiler(IsolatePtr iso_ptr) {
+  Isolate* iso = static_cast<Isolate*>(iso_ptr);
+  Locker locker(iso);
+  Isolate::Scope isolate_scope(iso);
+  HandleScope handle_scope(iso);
+
+  V8HeapProfiler* c = new V8HeapProfiler;
+  c->iso = iso;
+  c->ptr = iso->GetHeapProfiler();
+  return c;
+}
+
+//  v8::OutputStream is required for snapshot serialization
+class BufferOutputStream : public v8::OutputStream {
+ public:
+  BufferOutputStream() : buffer(new ExternalStringResource()) {}
+
+  void EndOfStream() override {}
+  int GetChunkSize() override { return 1024 * 1024; }
+  WriteResult WriteAsciiChunk(char* data, int size) override {
+    buffer->Append(data, size);
+    return kContinue;
+  }
+
+  Local<String> ToString(Isolate* isolate) {
+    return String::NewExternalOneByte(isolate,
+                                      buffer.release()).ToLocalChecked();
+  }
+
+ private:
+  class ExternalStringResource : public String::ExternalOneByteStringResource {
+   public:
+    void Append(char* data, size_t count) {
+      store.append(data, count);
+    }
+
+    const char* data() const override { return store.data(); }
+    size_t length() const override { return store.size(); }
+
+   private:
+    std::string store;
+  };
+
+  std::unique_ptr<ExternalStringResource> buffer;
+};
+
+const char* TakeHeapSnapshot(V8HeapProfiler* profiler) {
+    if (profiler->iso == nullptr) {
+      return nullptr;
+    }
+    Locker locker(profiler->iso);
+    Isolate::Scope isolate_scope(profiler->iso);
+    HandleScope handle_scope(profiler->iso);
+    const HeapSnapshot* snapshot = profiler->ptr->TakeHeapSnapshot();
+    BufferOutputStream stream;
+    snapshot->Serialize(&stream);
+    const_cast<HeapSnapshot*>(snapshot)->Delete();
+    String::Utf8Value json(profiler->iso, stream.ToString(profiler->iso));
+    return CopyString(json);
+}
+
+
 /********** CpuProfiler **********/
 
 CPUProfiler* NewCPUProfiler(IsolatePtr iso_ptr) {

--- a/v8go.cc
+++ b/v8go.cc
@@ -305,16 +305,14 @@ class BufferOutputStream : public v8::OutputStream {
   }
 
   Local<String> ToString(Isolate* isolate) {
-    return String::NewExternalOneByte(isolate,
-                                      buffer.release()).ToLocalChecked();
+    return String::NewExternalOneByte(isolate, buffer.release())
+        .ToLocalChecked();
   }
 
  private:
   class ExternalStringResource : public String::ExternalOneByteStringResource {
    public:
-    void Append(char* data, size_t count) {
-      store.append(data, count);
-    }
+    void Append(char* data, size_t count) { store.append(data, count); }
 
     const char* data() const override { return store.data(); }
     size_t length() const override { return store.size(); }
@@ -327,20 +325,19 @@ class BufferOutputStream : public v8::OutputStream {
 };
 
 const char* TakeHeapSnapshot(V8HeapProfiler* profiler) {
-    if (profiler->iso == nullptr) {
-      return nullptr;
-    }
-    Locker locker(profiler->iso);
-    Isolate::Scope isolate_scope(profiler->iso);
-    HandleScope handle_scope(profiler->iso);
-    const HeapSnapshot* snapshot = profiler->ptr->TakeHeapSnapshot();
-    BufferOutputStream stream;
-    snapshot->Serialize(&stream);
-    const_cast<HeapSnapshot*>(snapshot)->Delete();
-    String::Utf8Value json(profiler->iso, stream.ToString(profiler->iso));
-    return CopyString(json);
+  if (profiler->iso == nullptr) {
+    return nullptr;
+  }
+  Locker locker(profiler->iso);
+  Isolate::Scope isolate_scope(profiler->iso);
+  HandleScope handle_scope(profiler->iso);
+  const HeapSnapshot* snapshot = profiler->ptr->TakeHeapSnapshot();
+  BufferOutputStream stream;
+  snapshot->Serialize(&stream);
+  const_cast<HeapSnapshot*>(snapshot)->Delete();
+  String::Utf8Value json(profiler->iso, stream.ToString(profiler->iso));
+  return CopyString(json);
 }
-
 
 /********** CpuProfiler **********/
 

--- a/v8go.h
+++ b/v8go.h
@@ -15,12 +15,16 @@ typedef v8::CpuProfiler* CpuProfilerPtr;
 typedef v8::CpuProfile* CpuProfilePtr;
 typedef const v8::CpuProfileNode* CpuProfileNodePtr;
 typedef v8::ScriptCompiler::CachedData* ScriptCompilerCachedDataPtr;
+typedef v8::HeapProfiler* HeapProfilerPtr;
 
 extern "C" {
 #else
 // Opaque to cgo, but useful to treat it as a pointer to a distinct type
 typedef struct v8Isolate v8Isolate;
 typedef v8Isolate* IsolatePtr;
+
+typedef struct v8HeapProfiler v8HeapProfiler;
+typedef v8HeapProfiler* HeapProfilerPtr;
 
 typedef struct v8CpuProfiler v8CpuProfiler;
 typedef v8CpuProfiler* CpuProfilerPtr;
@@ -76,6 +80,11 @@ typedef struct {
   ScriptCompilerCachedData cachedData;
   int compileOption;
 } CompileOptions;
+
+typedef struct {
+  HeapProfilerPtr ptr;
+  IsolatePtr iso;
+} V8HeapProfiler;
 
 typedef struct {
   CpuProfilerPtr ptr;
@@ -155,6 +164,9 @@ extern ScriptCompilerCachedData* UnboundScriptCreateCodeCache(
 extern void ScriptCompilerCachedDataDelete(
     ScriptCompilerCachedData* cached_data);
 extern RtnValue UnboundScriptRun(ContextPtr ctx_ptr, UnboundScriptPtr us_ptr);
+
+extern V8HeapProfiler* NewHeapProfiler(IsolatePtr iso_ptr);
+extern const char* TakeHeapSnapshot(V8HeapProfiler* ptr);
 
 extern CPUProfiler* NewCPUProfiler(IsolatePtr iso_ptr);
 extern void CPUProfilerDispose(CPUProfiler* ptr);


### PR DESCRIPTION
This PR introduces [HeapProfiler](https://github.com/rogchap/v8go/blob/10e762dc4017337a7033a09ba3d2a0efa866ce05/deps/include/v8-profiler.h#L811) class from v8 - specifically ability to take [heap snapshots](https://github.com/rogchap/v8go/blob/10e762dc4017337a7033a09ba3d2a0efa866ce05/deps/include/v8-profiler.h#L897). Goal is to provide visibility into memory allocations happening in the v8 isolate heap at a point in time and gradually evolve `heap_profiler.go` to surface more advanced v8 memory profiler features.