### PR TITLE
shared array buffers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v0.10.0] - 2023-04-10
+
+### Changed
+- Required Go version changed to 1.17 (needed for SharedArrayBuffer support)
+
+### Added
+- Support for getting the underlying data (as a `[]byte`) from a SharedArrayBuffer
+
+### Fixed
+- Upgrade to V8 11.1.277.13
+
+
 ## [v0.9.0] - 2023-03-30
 
 ### Fixed

--- a/function_template.go
+++ b/function_template.go
@@ -83,6 +83,7 @@ func (tmpl *FunctionTemplate) GetFunction(ctx *Context) *Function {
 
 // Note that ideally `thisAndArgs` would be split into two separate arguments, but they were combined
 // to workaround an ERROR_COMMITMENT_LIMIT error on windows that was detected in CI.
+//
 //export goFunctionCallback
 func goFunctionCallback(ctxref int, cbref int, thisAndArgs *C.ValuePtr, argsCount int) C.ValuePtr {
 	ctx := getContext(ctxref)

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module rogchap.com/v8go
 
-go 1.16
+go 1.17

--- a/v8go.cc
+++ b/v8go.cc
@@ -1670,4 +1670,45 @@ const char* Version() {
 void SetFlags(const char* flags) {
   V8::SetFlagsFromString(flags);
 }
+
+/********** SharedArrayBuffer & BackingStore ***********/
+
+struct v8BackingStore {
+  v8BackingStore(std::shared_ptr<v8::BackingStore>&& ptr)
+    : backing_store{ptr}
+  {}
+  std::shared_ptr<v8::BackingStore> backing_store;
+};
+
+BackingStorePtr SharedArrayBufferGetBackingStore(ValuePtr ptr) {
+  LOCAL_VALUE(ptr);
+  auto buffer = Local<SharedArrayBuffer>::Cast(value);
+  auto backing_store = buffer->GetBackingStore();
+  auto proxy = new v8BackingStore(std::move(backing_store));
+  return proxy;
+}
+
+void BackingStoreRelease(BackingStorePtr ptr) {
+  if (ptr == nullptr){
+    return;
+  }
+  ptr->backing_store.reset();
+  delete ptr;
+}
+
+void* BackingStoreData(BackingStorePtr ptr) {
+  if (ptr == nullptr){
+    return nullptr;
+  }
+
+  return ptr->backing_store->Data();
+}
+
+size_t BackingStoreByteLength(BackingStorePtr ptr) {
+  if (ptr == nullptr){
+    return 0;
+  }
+  return ptr->backing_store->ByteLength();
+}
+
 }

--- a/v8go.cc
+++ b/v8go.cc
@@ -1675,8 +1675,7 @@ void SetFlags(const char* flags) {
 
 struct v8BackingStore {
   v8BackingStore(std::shared_ptr<v8::BackingStore>&& ptr)
-    : backing_store{ptr}
-  {}
+      : backing_store{ptr} {}
   std::shared_ptr<v8::BackingStore> backing_store;
 };
 
@@ -1689,7 +1688,7 @@ BackingStorePtr SharedArrayBufferGetBackingStore(ValuePtr ptr) {
 }
 
 void BackingStoreRelease(BackingStorePtr ptr) {
-  if (ptr == nullptr){
+  if (ptr == nullptr) {
     return;
   }
   ptr->backing_store.reset();
@@ -1697,7 +1696,7 @@ void BackingStoreRelease(BackingStorePtr ptr) {
 }
 
 void* BackingStoreData(BackingStorePtr ptr) {
-  if (ptr == nullptr){
+  if (ptr == nullptr) {
     return nullptr;
   }
 
@@ -1705,10 +1704,9 @@ void* BackingStoreData(BackingStorePtr ptr) {
 }
 
 size_t BackingStoreByteLength(BackingStorePtr ptr) {
-  if (ptr == nullptr){
+  if (ptr == nullptr) {
     return 0;
   }
   return ptr->backing_store->ByteLength();
 }
-
 }

--- a/v8go.h
+++ b/v8go.h
@@ -35,6 +35,10 @@ typedef struct v8ScriptCompilerCachedData v8ScriptCompilerCachedData;
 typedef const v8ScriptCompilerCachedData* ScriptCompilerCachedDataPtr;
 #endif
 
+// Opaque to both C and C++
+typedef struct v8BackingStore v8BackingStore;
+typedef v8BackingStore* BackingStorePtr;
+
 #include <stddef.h>
 #include <stdint.h>
 
@@ -306,6 +310,11 @@ ValuePtr FunctionSourceMapUrl(ValuePtr ptr);
 
 const char* Version();
 extern void SetFlags(const char* flags);
+
+extern BackingStorePtr SharedArrayBufferGetBackingStore(ValuePtr ptr);
+extern void BackingStoreRelease(BackingStorePtr ptr);
+extern void* BackingStoreData(BackingStorePtr ptr);
+extern size_t BackingStoreByteLength(BackingStorePtr ptr);
 
 #ifdef __cplusplus
 }  // extern "C"

--- a/value_test.go
+++ b/value_test.go
@@ -759,4 +759,14 @@ func TestValueArrayBufferContents(t *testing.T) {
 	if buf[3] != 0 {
 		t.Fatalf("expected buf[1] to be 0")
 	}
+
+	// ensure there's an error if we call the method on something that isn't a SharedArrayBuffer
+	val, err = ctx.RunScript("7", "test2.js")
+	if err != nil {
+		t.Fatalf("error running trivial script")
+	}
+	_, _, err = val.SharedArrayBufferGetContents()
+	if err == nil {
+		t.Fatalf("Expected an error trying call SharedArrayBufferGetContents on value of incorrect type")
+	}
 }

--- a/value_test.go
+++ b/value_test.go
@@ -741,6 +741,9 @@ func TestValueArrayBufferContents(t *testing.T) {
 	}
 
 	buf, cleanup, err := val.SharedArrayBufferGetContents()
+	if err != nil {
+		t.Fatalf("error getting array buffer contents: %#v", err)
+	}
 	defer cleanup()
 
 	if len(buf) != 1024 {

--- a/value_test.go
+++ b/value_test.go
@@ -7,7 +7,6 @@ package v8go_test
 import (
 	"bytes"
 	"fmt"
-	"log"
 	"math"
 	"math/big"
 	"reflect"
@@ -715,7 +714,6 @@ func TestValueMarshalJSON(t *testing.T) {
 
 func TestValueArrayBufferContents(t *testing.T) {
 	t.Parallel()
-	log.Printf("v8.Version(): %#v\n", v8.Version())
 	iso := v8.NewIsolate()
 	defer iso.Dispose()
 


### PR DESCRIPTION
Adds support for reading the contents of a SharedArrayBuffer in Go (as a `[]byte`). 