### PR TITLE
Add Heap Space Statistics in v8go

### DIFF
--- a/isolate_test.go
+++ b/isolate_test.go
@@ -296,3 +296,18 @@ func makeObject() interface{} {
 		"b": "AAAABBBBAAAABBBBAAAABBBBAAAABBBBAAAABBBB",
 	}
 }
+
+func TestIsolateGetHeapSpaceStatistics(t *testing.T) {
+	t.Parallel()
+	iso := v8.NewIsolate()
+	defer iso.Dispose()
+
+	heapSpaceStats := iso.GetHeapSpaceStatistics()
+
+	for _, stats := range heapSpaceStats {
+		if stats.SpaceName == "new_space" && (stats.SpaceSize <= 0 || stats.SpaceUsedSize <= 0) {
+			t.Errorf("expected non-zero size for heap space, got %d size for %s", stats.SpaceSize, stats.SpaceName)
+		}
+	}
+
+}

--- a/v8go.cc
+++ b/v8go.cc
@@ -193,6 +193,24 @@ int IsolateIsExecutionTerminating(IsolatePtr iso) {
   return iso->IsExecutionTerminating();
 }
 
+/********** Heap Statistics **********/
+
+size_t NumberOfHeapSpaces(IsolatePtr iso) {
+  return iso->NumberOfHeapSpaces();
+}
+
+IsolateHeapSpaceStatistics IsolateGetHeapSpaceStatistics(IsolatePtr iso,
+                                                         size_t index) {
+  if (iso == nullptr) {
+    return IsolateHeapSpaceStatistics{0};
+  }
+  v8::HeapSpaceStatistics hs;
+  iso->GetHeapSpaceStatistics(&hs, index);
+  return IsolateHeapSpaceStatistics{
+      hs.space_name(), hs.space_size(), hs.space_used_size(),
+      hs.space_available_size(), hs.physical_space_size()};
+}
+
 IsolateHStatistics IsolationGetHeapStatistics(IsolatePtr iso) {
   if (iso == nullptr) {
     return IsolateHStatistics{0};

--- a/v8go.h
+++ b/v8go.h
@@ -130,6 +130,14 @@ typedef struct {
 } IsolateHStatistics;
 
 typedef struct {
+  const char* space_name;
+  size_t space_size;
+  size_t space_used_size;
+  size_t space_available_size;
+  size_t physical_space_size;
+} IsolateHeapSpaceStatistics;
+
+typedef struct {
   const uint64_t* word_array;
   int word_count;
   int sign_bit;
@@ -142,6 +150,9 @@ extern void IsolateDispose(IsolatePtr ptr);
 extern void IsolateTerminateExecution(IsolatePtr ptr);
 extern int IsolateIsExecutionTerminating(IsolatePtr ptr);
 extern IsolateHStatistics IsolationGetHeapStatistics(IsolatePtr ptr);
+extern size_t NumberOfHeapSpaces(IsolatePtr ptr);
+extern IsolateHeapSpaceStatistics IsolateGetHeapSpaceStatistics(IsolatePtr ptr,
+                                                                size_t index);
 
 extern ValuePtr IsolateThrowException(IsolatePtr iso, ValuePtr value);
 


### PR DESCRIPTION
This PR surfaces [HeapSpaceStatistics](https://chromium.googlesource.com/v8/v8.git/+/HEAD/include/v8-statistics.h#162) from v8 - it provides visibility into memory utilization across different v8 isolate heap segments.