### PR TITLE
Use profiles to track object allocation and release.

### DIFF
--- a/context.go
+++ b/context.go
@@ -71,6 +71,7 @@ func NewContext(opt ...ContextOption) *Context {
 		ptr: C.NewContext(opts.iso.ptr, opts.gTmpl.ptr, C.int(ref)),
 		iso: opts.iso,
 	}
+	addContext(ctx)
 	ctx.register()
 	runtime.KeepAlive(opts.gTmpl)
 	return ctx
@@ -123,6 +124,7 @@ func (c *Context) PerformMicrotaskCheckpoint() {
 // Access to any values associated with the context after calling Close may panic.
 func (c *Context) Close() {
 	c.deregister()
+	delContext(c)
 	C.ContextFree(c.ptr)
 	c.ptr = nil
 }

--- a/isolate.go
+++ b/isolate.go
@@ -57,6 +57,7 @@ func NewIsolate() *Isolate {
 		ptr: C.NewIsolate(),
 		cbs: make(map[int]FunctionCallback),
 	}
+	addIsolate(iso)
 	iso.null = newValueNull(iso)
 	iso.undefined = newValueUndefined(iso)
 	return iso
@@ -143,6 +144,7 @@ func (i *Isolate) Dispose() {
 	if i.ptr == nil {
 		return
 	}
+	delIsolate(i)
 	C.IsolateDispose(i.ptr)
 	i.ptr = nil
 }

--- a/v8go_noprofile.go
+++ b/v8go_noprofile.go
@@ -1,0 +1,13 @@
+// Copyright 2023 the v8go contributors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+//go:build !v8goprofile
+
+package v8go
+
+func addIsolate(iso *Isolate) {}
+func delIsolate(iso *Isolate) {}
+
+func addContext(ctx *Context) {}
+func delContext(ctx *Context) {}

--- a/v8go_profile.go
+++ b/v8go_profile.go
@@ -1,0 +1,33 @@
+// Copyright 2023 the v8go contributors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+//go:build v8goprofile
+
+package v8go
+
+import "runtime/pprof"
+
+func getProfile(profileName string) *pprof.Profile {
+	if p := pprof.Lookup(); p != nil {
+		return p
+	}
+
+	return pprof.NewProfile(profileName)
+}
+
+func addIsolate(iso *Isolate) {
+	getProfile("rogchap.com/v8go/gv8go.Isolate").Add(iso, 1)
+}
+
+func delIsolate(iso *Isolate) {
+	getProfile("rogchap.com/v8go/gv8go.Isolate").Remove(iso)
+}
+
+func addContext(ctx *Context) {
+	getProfile("rogchap.com/v8go/gv8go.Context").Add(ctx, 1)
+}
+
+func delContext(ctx *Context) {
+	getProfile("rogchap.com/v8go/gv8go.Context").Remove(ctx)
+}


### PR DESCRIPTION
Use profiles to track allocation and release of objects within go, based on build tags.